### PR TITLE
fix(server): correct improper Close operation.

### DIFF
--- a/tuic-server/src/connection/handle_stream.rs
+++ b/tuic-server/src/connection/handle_stream.rs
@@ -67,7 +67,7 @@ impl Connection {
                     addr = self.inner.remote_address(),
                     user = self.auth,
                 );
-                self.close();
+                // self.close();
             }
         }
     }
@@ -117,7 +117,7 @@ impl Connection {
                     addr = self.inner.remote_address(),
                     user = self.auth,
                 );
-                self.close();
+                // self.close();
             }
         }
     }
@@ -158,7 +158,7 @@ impl Connection {
                     addr = self.inner.remote_address(),
                     user = self.auth,
                 );
-                self.close();
+                // self.close();
             }
         }
     }


### PR DESCRIPTION
碰到连接错误给链路关了做甚，给Firefox都整不会了，只是探测一下支不支持Websockets Over HTTP/2，结果一下给整个TCP连接关了？

修复：
#10 