### PR TITLE
 too many open streams 

### DIFF
--- a/tuic-client/src/connection/mod.rs
+++ b/tuic-client/src/connection/mod.rs
@@ -39,7 +39,7 @@ static CONNECTION: AsyncOnceCell<AsyncRwLock<Connection>> = AsyncOnceCell::const
 static TIMEOUT: AtomicCell<Duration> = AtomicCell::new(Duration::from_secs(0));
 
 pub const ERROR_CODE: VarInt = VarInt::from_u32(0);
-const DEFAULT_CONCURRENT_STREAMS: u32 = 32;
+const DEFAULT_CONCURRENT_STREAMS: u32 = 512;
 
 #[derive(Clone)]
 pub struct Connection {

--- a/tuic-server/src/connection/mod.rs
+++ b/tuic-server/src/connection/mod.rs
@@ -20,7 +20,7 @@ mod handle_task;
 mod udp_session;
 
 pub const ERROR_CODE: VarInt = VarInt::from_u32(0);
-pub const DEFAULT_CONCURRENT_STREAMS: u32 = 32;
+pub const DEFAULT_CONCURRENT_STREAMS: u32 = 512;
 
 #[derive(Clone)]
 pub struct Connection {


### PR DESCRIPTION
把服务端流的数量调大一点，不然用户一多就出现 too many open streams 然后断线，需要重连才行
其他没什么问题

<del>保守设置成 64</del>
一步到位，改成512了