### PR TITLE
Support TCP/UDP port forwarding in tuic-client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .vscode/
 target/
 .DS_Store
-
+.idea/

--- a/tuic-client/README.md
+++ b/tuic-client/README.md
@@ -151,7 +151,31 @@ tuic-client -c PATH/TO/CONFIG
 
         // Optional. Maximum packet size the socks5 server can receive from external, in bytes
         // Default: 1500
-        "max_packet_size": 1500
+        "max_packet_size": 1500,
+      
+        // Optional. TCP/UDP Forwarding allows you to forward one or more TCP/UDP ports
+        // from the server (or any remote host) to the client.
+        "tcp_forward": [
+            {
+              // The address to listen on.
+              "listen": "127.0.0.1:6600",
+              // The address to forward to.
+              "remote": "127.0.0.1:6800" 
+            }
+        ],
+        "udp_forward": [
+            {
+              "listen": "127.0.0.1:16600",
+              "remote": "127.0.0.1:16800",
+              // Optional. The timeout for each UDP session. 
+              // Default: 60 seconds
+              "timeout": "60s"
+            },
+            {
+              "listen": "127.0.0.1:44306",
+              "remote": "8.8.8.8:443"
+            }
+        ]
     },
 
     // Optional. Set the log level

--- a/tuic-client/src/config.rs
+++ b/tuic-client/src/config.rs
@@ -143,6 +143,33 @@ pub struct Local {
 
     #[serde(default = "default::local::max_packet_size")]
     pub max_packet_size: usize,
+
+    #[serde(default)]
+    pub tcp_forward: Vec<TcpForward>,
+
+    #[serde(default)]
+    pub udp_forward: Vec<UdpForward>,
+}
+
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TcpForward {
+    pub listen: SocketAddr,
+    #[serde(deserialize_with = "deserialize_server")]
+    pub remote: (String, u16),
+}
+
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UdpForward {
+    pub listen: SocketAddr,
+    #[serde(deserialize_with = "deserialize_server")]
+    pub remote: (String, u16),
+    #[serde(
+        default = "default::forward::udp_timeout",
+        deserialize_with = "deserialize_duration"
+    )]
+    pub timeout: Duration,
 }
 
 impl Config {
@@ -266,6 +293,13 @@ mod default {
     pub mod local {
         pub fn max_packet_size() -> usize {
             1500
+        }
+    }
+
+    pub mod forward {
+        use std::time::Duration;
+        pub fn udp_timeout() -> Duration {
+            Duration::from_secs(60)
         }
     }
 

--- a/tuic-client/src/forward.rs
+++ b/tuic-client/src/forward.rs
@@ -210,7 +210,7 @@ async fn run_udp_forwarder(entry: UdpForward) {
 
 async fn expire_after(assoc_id: u16, timeout: Duration) {
     tokio::time::sleep(timeout).await;
-    if let Some(session) = UDP_SESSIONS.get().and_then(|m| Some(m)) {
+    if let Some(session) = UDP_SESSIONS.get() {
         let mut w = session.write().await;
         if let Some(_s) = w.remove(&assoc_id) {
             debug!(

--- a/tuic-client/src/forward.rs
+++ b/tuic-client/src/forward.rs
@@ -1,0 +1,230 @@
+use std::{
+    collections::HashMap,
+    net::{SocketAddr, TcpListener as StdTcpListener},
+    sync::{
+        Arc,
+        atomic::{AtomicU16, Ordering},
+    },
+    time::Duration,
+};
+
+use bytes::Bytes;
+use once_cell::sync::OnceCell;
+use socket2::{Domain, Protocol, SockAddr, Socket, Type};
+use tokio::{
+    io,
+    io::AsyncWriteExt,
+    net::{TcpListener, UdpSocket},
+    sync::RwLock as AsyncRwLock,
+};
+use tracing::{debug, info, warn};
+use tuic::Address as TuicAddress;
+
+use crate::{
+    config::{TcpForward, UdpForward},
+    connection::Connection as TuicConnection,
+    error::Error,
+};
+
+// Global UDP forward session registry
+pub static UDP_SESSIONS: OnceCell<AsyncRwLock<HashMap<u16, ForwardUdpSession>>> = OnceCell::new();
+static NEXT_ASSOC_ID: AtomicU16 = AtomicU16::new(0);
+
+fn next_assoc_id() -> u16 {
+    // Use high bit set to avoid collision with SOCKS5-generated assoc IDs
+    0x8000 | (NEXT_ASSOC_ID.fetch_add(1, Ordering::Relaxed) & 0x7fff)
+}
+
+#[derive(Clone)]
+pub struct ForwardUdpSession {
+    socket: Arc<UdpSocket>,
+    src_addr: SocketAddr,
+    assoc_id: u16,
+}
+
+impl ForwardUdpSession {
+    pub fn new(socket: Arc<UdpSocket>, src_addr: SocketAddr, assoc_id: u16) -> Self {
+        Self {
+            socket,
+            src_addr,
+            assoc_id,
+        }
+    }
+
+    pub async fn send(&self, pkt: Bytes) -> Result<(), Error> {
+        if let Err(err) = self.socket.send_to(&pkt, self.src_addr).await {
+            warn!(
+                "[forward-udp] [{assoc:#06x}] failed sending packet to {dst}: {err}",
+                assoc = self.assoc_id,
+                dst = self.src_addr,
+            );
+            return Err(Error::Io(err));
+        }
+        Ok(())
+    }
+}
+
+pub async fn start(tcp: Vec<TcpForward>, udp: Vec<UdpForward>) {
+    // Init UDP session map
+    let _ = UDP_SESSIONS.set(AsyncRwLock::new(HashMap::new()));
+
+    for entry in tcp {
+        tokio::spawn(run_tcp_forwarder(entry));
+    }
+    for entry in udp {
+        tokio::spawn(run_udp_forwarder(entry));
+    }
+}
+
+async fn run_tcp_forwarder(entry: TcpForward) {
+    match create_tcp_listener(entry.listen) {
+        Ok(listener) => {
+            warn!(
+                "[forward-tcp] listening on {listen} -> {remote:?}",
+                listen = listener.local_addr().unwrap(),
+                remote = entry.remote
+            );
+            loop {
+                match listener.accept().await {
+                    Ok((mut inbound, peer)) => {
+                        let remote = entry.remote.clone();
+                        tokio::spawn(async move {
+                            info!("[forward-tcp] [{peer}] connected", peer = peer);
+                            let fut = async {
+                                let conn = TuicConnection::get_conn().await?;
+                                let remote_addr = TuicAddress::DomainAddress(remote.0, remote.1);
+                                let mut relay = conn.connect(remote_addr).await?;
+                                match io::copy_bidirectional(&mut inbound, &mut relay).await {
+                                    Ok((_lr, _rl)) => {
+                                        let _ = relay.shutdown().await;
+                                    }
+                                    Err(err) => {
+                                        warn!("[forward-tcp] [{peer}] relay error: {err}");
+                                    }
+                                }
+                                Ok::<(), Error>(())
+                            };
+                            if let Err(err) = fut.await {
+                                warn!("[forward-tcp] [{peer}] error: {err}");
+                            }
+                            debug!("[forward-tcp] [{peer}] closed");
+                        });
+                    }
+                    Err(err) => warn!("[forward-tcp] accept error: {err}"),
+                }
+            }
+        }
+        Err(err) => warn!("[forward-tcp] failed to bind listener: {err}"),
+    }
+}
+
+fn create_tcp_listener(addr: SocketAddr) -> Result<TcpListener, Error> {
+    let domain = match addr {
+        SocketAddr::V4(_) => Domain::IPV4,
+        SocketAddr::V6(_) => Domain::IPV6,
+    };
+    let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))
+        .map_err(|err| Error::Socket("failed to create tcp forward socket", err))?;
+    socket
+        .set_reuse_address(true)
+        .map_err(|err| Error::Socket("failed to set tcp forward socket reuse_address", err))?;
+    socket
+        .set_nonblocking(true)
+        .map_err(|err| Error::Socket("failed setting tcp forward socket as non-blocking", err))?;
+    socket
+        .bind(&SockAddr::from(addr))
+        .map_err(|err| Error::Socket("failed to bind tcp forward socket", err))?;
+    socket
+        .listen(i32::MAX)
+        .map_err(|err| Error::Socket("failed to listen on tcp forward socket", err))?;
+    TcpListener::from_std(StdTcpListener::from(socket))
+        .map_err(|err| Error::Socket("failed to create tcp forward socket", err))
+}
+
+async fn run_udp_forwarder(entry: UdpForward) {
+    let socket = match UdpSocket::bind(entry.listen).await {
+        Ok(s) => s,
+        Err(err) => {
+            warn!(
+                "[forward-udp] failed to bind {addr}: {err}",
+                addr = entry.listen
+            );
+            return;
+        }
+    };
+    let socket = Arc::new(socket);
+    warn!(
+        "[forward-udp] listening on {listen} -> {remote:?} timeout={timeout:?}",
+        listen = entry.listen,
+        remote = entry.remote,
+        timeout = entry.timeout
+    );
+
+    let mut buf = vec![0u8; 65535];
+    // Map from client src addr to assoc_id for this forwarder instance
+    let mut src_map: HashMap<SocketAddr, u16> = HashMap::new();
+
+    loop {
+        match socket.recv_from(&mut buf).await {
+            Ok((n, src_addr)) => {
+                let pkt = Bytes::copy_from_slice(&buf[..n]);
+                let assoc_id = match src_map.get(&src_addr).cloned() {
+                    Some(id) => id,
+                    None => {
+                        let id = next_assoc_id();
+                        // register session
+                        let session = ForwardUdpSession::new(socket.clone(), src_addr, id);
+                        UDP_SESSIONS
+                            .get()
+                            .unwrap()
+                            .write()
+                            .await
+                            .insert(id, session);
+                        src_map.insert(src_addr, id);
+                        // Spawn timeout watcher
+                        tokio::spawn(expire_after(id, entry.timeout));
+                        id
+                    }
+                };
+
+                let remote = entry.remote.clone();
+                tokio::spawn(async move {
+                    match TuicConnection::get_conn().await {
+                        Ok(conn) => {
+                            let remote_addr = TuicAddress::DomainAddress(remote.0, remote.1);
+                            if let Err(err) = conn.packet(pkt, remote_addr, assoc_id).await {
+                                warn!(
+                                    "[forward-udp] [{assoc:#06x}] send packet error: {err}",
+                                    assoc = assoc_id
+                                );
+                            }
+                        }
+                        Err(err) => warn!("[forward-udp] failed to get relay connection: {err}"),
+                    }
+                });
+            }
+            Err(err) => warn!("[forward-udp] recv_from error: {err}"),
+        }
+    }
+}
+
+async fn expire_after(assoc_id: u16, timeout: Duration) {
+    tokio::time::sleep(timeout).await;
+    if let Some(session) = UDP_SESSIONS.get().and_then(|m| Some(m)) {
+        let mut w = session.write().await;
+        if let Some(_s) = w.remove(&assoc_id) {
+            debug!(
+                "[forward-udp] [{assoc:#06x}] timeout; dissociate",
+                assoc = assoc_id
+            );
+            if let Ok(conn) = TuicConnection::get_conn().await {
+                if let Err(err) = conn.dissociate(assoc_id).await {
+                    warn!(
+                        "[forward-udp] [{assoc:#06x}] dissociate error: {err}",
+                        assoc = assoc_id
+                    );
+                }
+            }
+        }
+    }
+}

--- a/tuic-client/src/main.rs
+++ b/tuic-client/src/main.rs
@@ -13,6 +13,7 @@ use crate::{
 mod config;
 mod connection;
 mod error;
+mod forward;
 mod socks5;
 mod utils;
 
@@ -74,6 +75,8 @@ async fn main() -> eyre::Result<()> {
             process::exit(1);
         }
     }
+
+    forward::start(cfg.local.tcp_forward.clone(), cfg.local.udp_forward.clone()).await;
 
     match Socks5Server::set_config(cfg.local) {
         Ok(()) => {}


### PR DESCRIPTION
Insipred by hysteria's tcp/udp port forwarding capabilities, I add this feature to tuic.
https://v2.hysteria.network/docs/advanced/Full-Client-Config/#tcp-forwarding

The user can open one or more port(s) on the local machine, connections to which will be forwarded to the remote host and from there onto a given destination.