### PR TITLE
feat: Add ACL in tuic-server and reject client's access to server's localhost by default, implement SOCKS5 outbound

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
@@ -27,12 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,9 +37,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arc-swap"
@@ -65,7 +59,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "time",
 ]
 
@@ -137,9 +131,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.13.3"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c953fe1ba023e6b7730c0d4b031d06f267f23a46167dcbd40316644b10a17ba"
+checksum = "879b6c89592deb404ba4dc0ae6b58ffd1795c78991cbb5b8bc441c48a070440d"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -148,22 +142,23 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.30.0"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbfd150b5dbdb988bcc8fb1fe787eb6b7ee6180ca24da683b61ea5405f3d43ff"
+checksum = "a2b715a6010afb9e457ca2b7c9d2b9c344baa8baed7b38dc476034c171b32575"
 dependencies = [
  "bindgen",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "libloading",
 ]
 
 [[package]]
 name = "axum"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
+checksum = "8a18ed336352031311f4e0b4dd2ff392d4fbb370777c9d18d7fc9d7359f73871"
 dependencies = [
  "axum-core",
  "bytes",
@@ -180,8 +175,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
@@ -195,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.2"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
+checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
 dependencies = [
  "bytes",
  "futures-core",
@@ -206,7 +200,6 @@ dependencies = [
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
  "sync_wrapper",
  "tower-layer",
  "tower-service",
@@ -215,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45bf463831f5131b7d3c756525b305d40f1185b688565648a92e1392ca35713d"
+checksum = "9963ff19f40c6102c76756ef0a46004c0d58957d87259fc9208ff8441c12ab96"
 dependencies = [
  "axum",
  "axum-core",
@@ -230,17 +223,17 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "serde",
- "tower",
+ "serde_core",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
 name = "backtrace"
-version = "0.3.75"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -248,7 +241,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -259,25 +252,22 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
  "itertools",
- "lazy_static",
- "lazycell",
  "log",
  "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "shlex",
  "syn",
- "which",
 ]
 
 [[package]]
@@ -321,9 +311,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.35"
+version = "1.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "590f9024a68a8c40351881787f1934dc11afd69090f5edb6831464694d836ea3"
+checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -372,11 +362,10 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
@@ -486,9 +475,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
+checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
 dependencies = [
  "powerfmt",
 ]
@@ -566,12 +555,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -626,9 +615,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e178e4fba8a2726903f6ba98a6d221e76f9c12c650d5dc0e6afdc50677b49650"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
 
 [[package]]
 name = "fnv"
@@ -773,15 +762,15 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.3+wasi-0.2.4",
+ "wasi 0.14.7+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
@@ -810,9 +799,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "headers"
@@ -836,15 +825,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
  "http",
-]
-
-[[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -895,9 +875,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "humantime-serde"
@@ -953,9 +933,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
+checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
  "base64",
  "bytes",
@@ -977,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.63"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1114,9 +1094,9 @@ checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
-version = "2.11.0"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1145,7 +1125,7 @@ dependencies = [
  "rustls-pki-types",
  "serde",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
 ]
 
@@ -1184,9 +1164,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1231,9 +1211,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1246,12 +1226,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "lexopt"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1259,9 +1233,9 @@ checksum = "9fa0e2a1fcbe2f6be6c42e342259976206b383122fc152e872795338b5a3f3a7"
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libloading"
@@ -1270,20 +1244,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.3",
+ "windows-targets 0.53.4",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -1303,9 +1271,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "lru-slab"
@@ -1321,9 +1289,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "mime"
@@ -1421,9 +1389,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -1573,10 +1541,10 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "web-time",
@@ -1594,11 +1562,11 @@ dependencies = [
  "lru-slab",
  "rand",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1620,9 +1588,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
@@ -1664,9 +1632,9 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0068c5b3cab1d4e271e0bb6539c87563c43411cad90b057b15c79958fbeb41f7"
+checksum = "5fae430c6b28f1ad601274e78b7dffa0546de0b73b4cd32f46723c0c2a16f7a5"
 dependencies = [
  "aws-lc-rs",
  "pem",
@@ -1687,9 +1655,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.2"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1699,9 +1667,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1780,12 +1748,6 @@ checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
@@ -1801,35 +1763,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys 0.60.2",
+ "linux-raw-sys",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.31"
+version = "0.23.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
+checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -1900,9 +1849,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.4"
+version = "0.103.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -1933,11 +1882,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -1948,9 +1897,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
-version = "3.3.0"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1961,9 +1910,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1971,18 +1920,28 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1991,24 +1950,26 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.17"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
 dependencies = [
  "itoa",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2022,11 +1983,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+checksum = "5417783452c2be558477e104686f7de5dae53dba813c28435e0e70f82d9b04ee"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2177,15 +2138,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.21.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.8",
- "windows-sys 0.60.2",
+ "rustix",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -2199,11 +2160,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 2.0.16",
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -2219,9 +2180,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2259,11 +2220,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.42"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca967379f9d8eb8058d86ed467d81d03e81acd45757e4ca341c24affbe8e8e3"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
+ "itoa",
  "libc",
  "num-conv",
  "num_threads",
@@ -2275,15 +2237,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9108bb380861b07264b950ded55a44a14a4adc68b9f5efd85aafc3aa4d40a68"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "time-macros"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7182799245a7264ce590b349d90338f1c1affad93d2639aed5f8f69c090b334c"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2347,9 +2309,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
@@ -2383,14 +2345,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+checksum = "00e5e5d9bf2475ac9d4f0d9edab68cc573dc2fd644b0dba36b0c30a92dd9eaa0"
 dependencies = [
  "indexmap",
- "serde",
- "serde_spanned 1.0.0",
- "toml_datetime 0.7.0",
+ "serde_core",
+ "serde_spanned 1.0.2",
+ "toml_datetime 0.7.2",
  "toml_parser",
  "toml_writer",
  "winnow",
@@ -2407,11 +2369,11 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+checksum = "32f1085dec27c2b6632b04c80b3bb1b4300d6495d1e129693bdda7d91e72eec1"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2430,9 +2392,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+checksum = "4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627"
 dependencies = [
  "winnow",
 ]
@@ -2445,9 +2407,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
+checksum = "d163a63c116ce562a22cda521fcc4d79152e7aba014456fb5eb442f6d6a10109"
 
 [[package]]
 name = "tower"
@@ -2567,7 +2529,7 @@ dependencies = [
  "futures-util",
  "parking_lot",
  "register-count",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tuic",
  "uuid",
 ]
@@ -2594,7 +2556,7 @@ dependencies = [
  "socket2",
  "socks5-proto",
  "socks5-server",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tikv-jemallocator",
  "time",
  "tokio",
@@ -2613,7 +2575,7 @@ dependencies = [
  "bytes",
  "eyre",
  "quinn",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "tuic",
@@ -2649,11 +2611,11 @@ dependencies = [
  "sha2",
  "socket2",
  "tempfile",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tikv-jemallocator",
  "time",
  "tokio",
- "toml 0.9.5",
+ "toml 0.9.7",
  "tracing",
  "tracing-subscriber",
  "tuic",
@@ -2679,9 +2641,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "untrusted"
@@ -2764,30 +2726,40 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.3+wasi-0.2.4"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
 dependencies = [
  "bumpalo",
  "log",
@@ -2799,9 +2771,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2812,9 +2784,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2822,9 +2794,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2835,18 +2807,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2881,31 +2853,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
-]
-
-[[package]]
 name = "winapi-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
+version = "0.62.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+checksum = "6844ee5416b285084d3d3fffd743b925a6c9385455f64f6d4fa3031c4c2749a9"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -2916,9 +2876,9 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "edb307e42a74fb6de9bf3a02d9712678b22399c87e6fa869d6dfcd8c1b7754e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2927,9 +2887,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "c0abd1ddbc6964ac14db11c7213d6532ef34bd9aa042c2e5935f59d7908b46a5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2938,24 +2898,24 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
 dependencies = [
  "windows-link",
 ]
@@ -2993,7 +2953,16 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.3",
+ "windows-targets 0.53.4",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -3029,9 +2998,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.3"
+version = "0.53.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "2d42b7b7f66d2a06854650af09cfdf8713e427a439c97ad65a6375318033ac4b"
 dependencies = [
  "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
@@ -3193,9 +3162,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"
@@ -3216,7 +3185,7 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "time",
 ]
 
@@ -3255,18 +3224,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3296,9 +3265,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,6 +1161,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ip_network"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2f047c0a98b2f299aa5d6d7088443570faae494e9ae1305e48be000c9e0eb1"
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2555,7 +2561,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuic"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "bytes",
  "futures-util",
@@ -2568,7 +2574,7 @@ dependencies = [
 
 [[package]]
 name = "tuic-client"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2602,7 +2608,7 @@ dependencies = [
 
 [[package]]
 name = "tuic-quinn"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "bytes",
  "eyre",
@@ -2616,7 +2622,7 @@ dependencies = [
 
 [[package]]
 name = "tuic-server"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "arc-swap",
  "axum",
@@ -2630,6 +2636,7 @@ dependencies = [
  "humantime",
  "humantime-serde",
  "instant-acme",
+ "ip_network",
  "lexopt",
  "quinn",
  "rcgen",

--- a/tuic-server/Cargo.toml
+++ b/tuic-server/Cargo.toml
@@ -52,6 +52,7 @@ serde_json = { version = "1", default-features = false, features = ["std"] }
 figment = { version = "0.10", features = ["toml"] }
 educe = { version = "0.6", default-features = false, features = ["Default"] }
 humantime-serde = "1"
+ip_network = "0.4"
 
 # Logging
 time = { version = "0.3", features = ["macros", "local-offset"] }

--- a/tuic-server/src/acl.rs
+++ b/tuic-server/src/acl.rs
@@ -224,10 +224,10 @@ impl fmt::Display for AclRule {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} {}", self.outbound, self.addr)?;
         if let Some(ports) = &self.ports {
-            write!(f, " {}", ports)?;
+            write!(f, " {ports}")?;
         }
         if let Some(hijack) = &self.hijack {
-            write!(f, " {}", hijack)?;
+            write!(f, " {hijack}")?;
         }
         Ok(())
     }
@@ -236,10 +236,10 @@ impl fmt::Display for AclRule {
 impl fmt::Display for AclAddress {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            AclAddress::Ip(ip) => write!(f, "{}", ip),
-            AclAddress::Cidr(cidr) => write!(f, "{}", cidr),
-            AclAddress::Domain(domain) => write!(f, "{}", domain),
-            AclAddress::WildcardDomain(domain) => write!(f, "{}", domain),
+            AclAddress::Ip(ip) => write!(f, "{ip}"),
+            AclAddress::Cidr(cidr) => write!(f, "{cidr}"),
+            AclAddress::Domain(domain) => write!(f, "{domain}"),
+            AclAddress::WildcardDomain(domain) => write!(f, "{domain}"),
             AclAddress::Localhost => write!(f, "localhost"),
             AclAddress::Any => write!(f, "*"),
         }
@@ -275,8 +275,8 @@ impl fmt::Display for AclProtocol {
 impl fmt::Display for AclPortSpec {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            AclPortSpec::Single(port) => write!(f, "{}", port),
-            AclPortSpec::Range(start, end) => write!(f, "{}-{}", start, end),
+            AclPortSpec::Single(port) => write!(f, "{port}"),
+            AclPortSpec::Range(start, end) => write!(f, "{start}-{end}"),
         }
     }
 }
@@ -387,7 +387,7 @@ pub(crate) fn parse_acl_port_entry(entry: &str) -> Result<AclPortEntry, String> 
         let protocol = match protocol_str.to_lowercase().as_str() {
             "tcp" => AclProtocol::Tcp,
             "udp" => AclProtocol::Udp,
-            _ => return Err(format!("Invalid protocol: {}", protocol_str)),
+            _ => return Err(format!("Invalid protocol: {protocol_str}")),
         };
         let port_spec = parse_port_spec(port_str)?;
         Ok(AclPortEntry {
@@ -410,13 +410,13 @@ fn parse_port_spec(port_str: &str) -> Result<AclPortSpec, String> {
         // Port range
         let start = start_str
             .parse::<u16>()
-            .map_err(|_| format!("Invalid start port: {}", start_str))?;
+            .map_err(|_| format!("Invalid start port: {start_str}"))?;
         let end = end_str
             .parse::<u16>()
-            .map_err(|_| format!("Invalid end port: {}", end_str))?;
+            .map_err(|_| format!("Invalid end port: {end_str}"))?;
 
         if start > end {
-            return Err(format!("Invalid port range: {} > {}", start, end));
+            return Err(format!("Invalid port range: {start} > {end}"));
         }
 
         Ok(AclPortSpec::Range(start, end))
@@ -424,7 +424,7 @@ fn parse_port_spec(port_str: &str) -> Result<AclPortSpec, String> {
         // Single port
         let port = port_str
             .parse::<u16>()
-            .map_err(|_| format!("Invalid port: {}", port_str))?;
+            .map_err(|_| format!("Invalid port: {port_str}"))?;
         Ok(AclPortSpec::Single(port))
     }
 }

--- a/tuic-server/src/acl.rs
+++ b/tuic-server/src/acl.rs
@@ -163,11 +163,11 @@ impl AclRule {
 
                 match &entry.port_spec {
                     AclPortSpec::Single(p) => {
-                        allowed.insert((*p, entry.protocol.clone()));
+                        allowed.insert((*p, entry.protocol));
                     }
                     AclPortSpec::Range(start, end) => {
                         for p in *start..=*end {
-                            allowed.insert((p, entry.protocol.clone()));
+                            allowed.insert((p, entry.protocol));
                         }
                     }
                 }
@@ -188,7 +188,7 @@ impl AclRule {
     }
 }
 /// A single port entry with optional protocol specification
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Copy)]
 pub struct AclPortEntry {
     /// Protocol (TCP, UDP, or both if None)
     pub protocol: Option<AclProtocol>,
@@ -197,14 +197,14 @@ pub struct AclPortEntry {
 }
 
 /// Protocol specification
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Copy)]
 pub enum AclProtocol {
     Tcp,
     Udp,
 }
 
 /// Port specification (single port or range)
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Copy)]
 pub enum AclPortSpec {
     /// Single port
     Single(u16),

--- a/tuic-server/src/acl.rs
+++ b/tuic-server/src/acl.rs
@@ -1,0 +1,695 @@
+use std::{
+    collections::HashSet,
+    fmt,
+    net::{IpAddr, SocketAddr, ToSocketAddrs},
+    str::FromStr,
+};
+
+use serde::Serialize;
+
+/// Represents a single ACL rule with parsed components
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct AclRule {
+    /// The outbound name to use for this rule (e.g., "allow", "reject",
+    /// "custom_outbound")
+    pub outbound: String,
+    /// The target address (IP, CIDR, domain, wildcard domain)
+    pub addr: AclAddress,
+    /// Optional port specifications
+    pub ports: Option<AclPorts>,
+    /// Optional hijack IP address for redirection
+    pub hijack: Option<String>,
+}
+
+/// Represents different types of addresses in ACL rules
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub enum AclAddress {
+    /// Single IP address (IPv4 or IPv6)
+    Ip(String),
+    /// CIDR notation (e.g., "10.6.0.0/16")
+    Cidr(String),
+    /// Domain name (e.g., "google.com")
+    Domain(String),
+    /// Wildcard domain (e.g., "*.google.com")
+    WildcardDomain(String),
+    /// Special localhost identifier
+    Localhost,
+    /// Match any address (when address is omitted)
+    Any,
+}
+
+/// Represents port specifications with optional protocols
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct AclPorts {
+    /// List of port ranges or single ports with optional protocols
+    pub entries: Vec<AclPortEntry>,
+}
+
+impl AclRule {
+    /// Returns `true` if the supplied socket address, port and transport
+    /// protocol satisfy this rule.
+    ///
+    /// * `addr` – remote IP address of the request.
+    /// * `port` – destination port the client wants to reach.
+    /// * `is_tcp` – `true` for TCP, `false` for UDP.
+    pub(crate) fn matching(&self, addr: SocketAddr, port: u16, is_tcp: bool) -> bool {
+        // ---------- address matching ----------
+        let addr_match = match &self.addr {
+            // Exact IP address
+            AclAddress::Ip(ip_str) => {
+                if let Ok(ip) = ip_str.parse::<IpAddr>() {
+                    addr.ip() == ip
+                } else {
+                    false
+                }
+            }
+
+            // CIDR block
+            AclAddress::Cidr(cidr_str) => {
+                if let Ok(net) = cidr_str.parse::<ip_network::IpNetwork>() {
+                    net.contains(addr.ip())
+                } else {
+                    false
+                }
+            }
+
+            // Exact domain name – resolve it and compare the resulting IPs
+            AclAddress::Domain(domain) => {
+                // Special‑case localhost to be deterministic and platform‑independent.
+                if domain.eq_ignore_ascii_case("localhost") {
+                    match addr.ip() {
+                        IpAddr::V4(v4) => v4.is_loopback(),
+                        IpAddr::V6(v6) => v6.is_loopback(),
+                    }
+                } else {
+                    // Resolve the domain (port is irrelevant, we just need the IPs)
+                    // Using `0` as a dummy port – `ToSocketAddrs` ignores it for name resolution.
+                    let resolver = (domain.as_str(), 0);
+                    match resolver.to_socket_addrs() {
+                        Ok(iter) => iter.map(|sa| sa.ip()).any(|ip| ip == addr.ip()),
+                        Err(_) => false,
+                    }
+                }
+            }
+
+            // Wild‑card domain (e.g. "*.example.com" or "suffix:example.com")
+            AclAddress::WildcardDomain(pattern) => {
+                // Strip leading "*." if present; also support the `suffix:` syntax.
+                let stripped = if let Some(rest) = pattern.strip_prefix("*.") {
+                    rest
+                } else if let Some(rest) = pattern.strip_prefix("suffix:") {
+                    rest
+                } else {
+                    // Not a recognised wildcard – treat as a literal domain.
+                    pattern.as_str()
+                };
+
+                // Special‑case localhost to be deterministic and platform‑independent.
+                if stripped.eq_ignore_ascii_case("localhost") {
+                    match addr.ip() {
+                        IpAddr::V4(v4) => v4.is_loopback(),
+                        IpAddr::V6(v6) => v6.is_loopback(),
+                    }
+                } else {
+                    // Resolve the base domain and compare IPs.
+                    let resolver = (stripped, 0);
+                    match resolver.to_socket_addrs() {
+                        Ok(iter) => iter.map(|sa| sa.ip()).any(|ip| ip == addr.ip()),
+                        Err(_) => false,
+                    }
+                }
+            }
+
+            // Loop‑back address – matches both IPv4 and IPv6 loop‑back.
+            AclAddress::Localhost => {
+                match addr.ip() {
+                    // IPv4 loopback (127.0.0.0/8, but we only need the exact address)
+                    IpAddr::V4(v4) if v4.is_loopback() => true,
+
+                    // IPv6 loopback (::1)
+                    IpAddr::V6(v6) if v6.is_loopback() => true,
+
+                    // Anything else does not match the “localhost” shortcut
+                    _ => false,
+                }
+            }
+
+            // Matches any address.
+            AclAddress::Any => true,
+        };
+
+        if !addr_match {
+            return false;
+        }
+
+        // ---------- port & protocol matching ----------
+        // If no port filter is defined, the rule matches any port.
+        if let Some(ports) = &self.ports {
+            // Build a set of (port, protocol) pairs that satisfy the rule.
+            // `protocol == None` means “either”.
+            let mut allowed = HashSet::new();
+
+            for entry in &ports.entries {
+                // Apply protocol filter if present.
+                let proto_ok = match entry.protocol {
+                    Some(AclProtocol::Tcp) => is_tcp,
+                    Some(AclProtocol::Udp) => !is_tcp,
+                    None => true,
+                };
+
+                if !proto_ok {
+                    continue;
+                }
+
+                match &entry.port_spec {
+                    AclPortSpec::Single(p) => {
+                        allowed.insert((*p, entry.protocol.clone()));
+                    }
+                    AclPortSpec::Range(start, end) => {
+                        for p in *start..=*end {
+                            allowed.insert((p, entry.protocol.clone()));
+                        }
+                    }
+                }
+            }
+
+            // If the rule defined ports but none survived the protocol filter,
+            // the request must be rejected.
+            if allowed.is_empty() {
+                return false;
+            }
+
+            // Finally, check that the requested port/protocol pair is allowed.
+            allowed.iter().any(|&(p, _)| p == port)
+        } else {
+            // No port restrictions → always true.
+            true
+        }
+    }
+}
+/// A single port entry with optional protocol specification
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct AclPortEntry {
+    /// Protocol (TCP, UDP, or both if None)
+    pub protocol: Option<AclProtocol>,
+    /// Port specification (single port or range)
+    pub port_spec: AclPortSpec,
+}
+
+/// Protocol specification
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+pub enum AclProtocol {
+    Tcp,
+    Udp,
+}
+
+/// Port specification (single port or range)
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub enum AclPortSpec {
+    /// Single port
+    Single(u16),
+    /// Port range (inclusive)
+    Range(u16, u16),
+}
+
+impl FromStr for AclRule {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        parse_acl_rule(s.trim())
+    }
+}
+
+impl fmt::Display for AclRule {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} {}", self.outbound, self.addr)?;
+        if let Some(ports) = &self.ports {
+            write!(f, " {}", ports)?;
+        }
+        if let Some(hijack) = &self.hijack {
+            write!(f, " {}", hijack)?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for AclAddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AclAddress::Ip(ip) => write!(f, "{}", ip),
+            AclAddress::Cidr(cidr) => write!(f, "{}", cidr),
+            AclAddress::Domain(domain) => write!(f, "{}", domain),
+            AclAddress::WildcardDomain(domain) => write!(f, "{}", domain),
+            AclAddress::Localhost => write!(f, "localhost"),
+            AclAddress::Any => write!(f, "*"),
+        }
+    }
+}
+
+impl fmt::Display for AclPorts {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let entries: Vec<String> = self.entries.iter().map(|e| e.to_string()).collect();
+        write!(f, "{}", entries.join(","))
+    }
+}
+
+impl fmt::Display for AclPortEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(protocol) = &self.protocol {
+            write!(f, "{}/{}", protocol, self.port_spec)
+        } else {
+            write!(f, "{}", self.port_spec)
+        }
+    }
+}
+
+impl fmt::Display for AclProtocol {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AclProtocol::Tcp => write!(f, "tcp"),
+            AclProtocol::Udp => write!(f, "udp"),
+        }
+    }
+}
+
+impl fmt::Display for AclPortSpec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AclPortSpec::Single(port) => write!(f, "{}", port),
+            AclPortSpec::Range(start, end) => write!(f, "{}-{}", start, end),
+        }
+    }
+}
+
+/// Parse a single ACL rule from string format
+pub(crate) fn parse_acl_rule(rule: &str) -> Result<AclRule, String> {
+    // Skip comments and empty lines
+    if rule.starts_with('#') || rule.is_empty() {
+        return Err("Comment or empty line".to_string());
+    }
+
+    let parts: Vec<&str> = rule.split_whitespace().collect();
+    if parts.is_empty() {
+        return Err("Empty rule".to_string());
+    }
+
+    let outbound = parts[0].to_string();
+
+    // Parse address (second part, optional)
+    let addr = if parts.len() > 1 {
+        parse_acl_address(parts[1])?
+    } else {
+        AclAddress::Any
+    };
+
+    // Parse ports (third part, optional)
+    // A solitary "*" after the address means “any port”, which we model by
+    // leaving `ports` as `None`.  All other strings are forwarded to the
+    // existing port parser.
+    let ports = if parts.len() > 2 {
+        if parts[2] == "*" {
+            None
+        } else {
+            Some(parse_acl_ports(parts[2])?)
+        }
+    } else {
+        None
+    };
+
+    // Parse hijack address (fourth part, optional)
+    let hijack = if parts.len() > 3 {
+        Some(parts[3].to_string())
+    } else {
+        None
+    };
+
+    Ok(AclRule {
+        outbound,
+        addr,
+        ports,
+        hijack,
+    })
+}
+
+/// Parse address component of ACL rule
+pub(crate) fn parse_acl_address(addr: &str) -> Result<AclAddress, String> {
+    if addr == "localhost" || addr == "suffix:localhost" {
+        Ok(AclAddress::Localhost)
+    } else if addr == "*" {
+        Ok(AclAddress::Any)
+    } else if addr.starts_with("*.") || addr.starts_with("suffix:") {
+        // Treat both leading "*." and explicit "suffix:" prefix as wildcard domain
+        // patterns
+        Ok(AclAddress::WildcardDomain(addr.to_string()))
+    } else if addr.contains('/') {
+        // CIDR notation
+        Ok(AclAddress::Cidr(addr.to_string()))
+    } else if addr.parse::<std::net::Ipv4Addr>().is_ok()
+        || addr.parse::<std::net::Ipv6Addr>().is_ok()
+    {
+        Ok(AclAddress::Ip(addr.to_string()))
+    } else {
+        // Assume it's a domain name
+        Ok(AclAddress::Domain(addr.to_string()))
+    }
+}
+
+impl FromStr for AclAddress {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        parse_acl_address(s.trim())
+    }
+}
+
+/// Parse port specification
+pub(crate) fn parse_acl_ports(ports_str: &str) -> Result<AclPorts, String> {
+    let entries: Result<Vec<_>, _> = ports_str
+        .split(',')
+        .map(|part| parse_acl_port_entry(part.trim()))
+        .collect();
+
+    Ok(AclPorts { entries: entries? })
+}
+
+impl FromStr for AclPorts {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        parse_acl_ports(s.trim())
+    }
+}
+
+/// Parse a single port entry (e.g., "80", "tcp/443", "1000-2000")
+pub(crate) fn parse_acl_port_entry(entry: &str) -> Result<AclPortEntry, String> {
+    // Check for protocol specification
+    if let Some((protocol_str, port_str)) = entry.split_once('/') {
+        let protocol = match protocol_str.to_lowercase().as_str() {
+            "tcp" => AclProtocol::Tcp,
+            "udp" => AclProtocol::Udp,
+            _ => return Err(format!("Invalid protocol: {}", protocol_str)),
+        };
+        let port_spec = parse_port_spec(port_str)?;
+        Ok(AclPortEntry {
+            protocol: Some(protocol),
+            port_spec,
+        })
+    } else {
+        // No protocol specified, matches both TCP and UDP
+        let port_spec = parse_port_spec(entry)?;
+        Ok(AclPortEntry {
+            protocol: None,
+            port_spec,
+        })
+    }
+}
+
+/// Parse port specification (single port or range)
+fn parse_port_spec(port_str: &str) -> Result<AclPortSpec, String> {
+    if let Some((start_str, end_str)) = port_str.split_once('-') {
+        // Port range
+        let start = start_str
+            .parse::<u16>()
+            .map_err(|_| format!("Invalid start port: {}", start_str))?;
+        let end = end_str
+            .parse::<u16>()
+            .map_err(|_| format!("Invalid end port: {}", end_str))?;
+
+        if start > end {
+            return Err(format!("Invalid port range: {} > {}", start, end));
+        }
+
+        Ok(AclPortSpec::Range(start, end))
+    } else {
+        // Single port
+        let port = port_str
+            .parse::<u16>()
+            .map_err(|_| format!("Invalid port: {}", port_str))?;
+        Ok(AclPortSpec::Single(port))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Tests for `AclRule::matching`.
+    //! They cover all address flavours (IP, CIDR, domain, wildcard‑domain,
+    //! localhost, any) and the port / protocol filtering logic.
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    use super::*;
+    /// Helper that builds a `SocketAddr` from an IPv4 string and a port.
+    fn v4(addr: &str, port: u16) -> SocketAddr {
+        SocketAddr::new(IpAddr::V4(addr.parse::<Ipv4Addr>().unwrap()), port)
+    }
+
+    /// Helper that builds a `SocketAddr` from an IPv6 string and a port.
+    fn v6(addr: &str, port: u16) -> SocketAddr {
+        SocketAddr::new(IpAddr::V6(addr.parse::<Ipv6Addr>().unwrap()), port)
+    }
+
+    #[test]
+    fn ip_exact_match() {
+        // rule accepts only 203.0.113.7
+        let rule = AclRule {
+            addr: AclAddress::Ip("203.0.113.7".into()),
+            ports: None,
+            outbound: "default".parse().unwrap(),
+            hijack: None,
+        };
+
+        assert!(rule.matching(v4("203.0.113.7", 12345), 12345, true));
+        assert!(!rule.matching(v4("203.0.113.8", 12345), 12345, true));
+        // IPv6 must not match an IPv4 rule
+        assert!(!rule.matching(v6("2001:db8::1", 12345), 12345, true));
+    }
+
+    #[test]
+    fn cidr_match() {
+        // 10.0.0.0/8
+        let rule = AclRule {
+            addr: AclAddress::Cidr("10.0.0.0/8".into()),
+            ports: None,
+            outbound: "default".parse().unwrap(),
+            hijack: None,
+        };
+
+        assert!(rule.matching(v4("10.1.2.3", 0), 0, false));
+        assert!(!rule.matching(v4("192.0.2.1", 0), 0, false));
+        // IPv6 never matches an IPv4 CIDR
+        assert!(!rule.matching(v6("::1", 0), 0, false));
+    }
+
+    #[test]
+    fn domain_match_localhost() {
+        // “localhost” resolves to 127.0.0.1 and ::1 on every platform
+        let rule = AclRule {
+            addr: AclAddress::Domain("localhost".into()),
+            ports: None,
+            outbound: "default".parse().unwrap(),
+            hijack: None,
+        };
+
+        // IPv4 localhost
+        assert!(rule.matching(v4("127.0.0.1", 0), 0, true));
+        // IPv6 localhost
+        assert!(rule.matching(v6("::1", 0), 0, true));
+        // Some other address must not match
+        assert!(!rule.matching(v4("8.8.8.8", 0), 0, true));
+    }
+
+    #[test]
+    fn wildcard_domain_match_suffix_localhost() {
+        // The implementation treats a leading “suffix:” as a wildcard.
+        // It will resolve the part after the prefix (here “localhost”).
+        let rule = AclRule {
+            addr: AclAddress::WildcardDomain("suffix:localhost".into()),
+            ports: None,
+            outbound: "default".parse().unwrap(),
+            hijack: None,
+        };
+
+        assert!(rule.matching(v4("127.0.0.1", 0), 0, true));
+        assert!(rule.matching(v6("::1", 0), 0, true));
+        // a non‑matching host
+        assert!(!rule.matching(v4("8.8.8.8", 0), 0, true));
+    }
+
+    #[test]
+    fn localhost_match() {
+        // Explicit localhost shortcut (both IPv4 and IPv6)
+        let rule = AclRule {
+            addr: AclAddress::Localhost,
+            ports: None,
+            outbound: "default".parse().unwrap(),
+            hijack: None,
+        };
+
+        assert!(rule.matching(v4("127.0.0.1", 0), 0, true));
+        assert!(rule.matching(v6("::1", 0), 0, true));
+        assert!(!rule.matching(v4("192.0.2.1", 0), 0, true));
+    }
+
+    #[test]
+    fn any_match() {
+        // “any” matches everything regardless of address.
+        let rule = AclRule {
+            addr: AclAddress::Any,
+            ports: None,
+            outbound: "default".parse().unwrap(),
+            hijack: None,
+        };
+
+        assert!(rule.matching(v4("203.0.113.1", 0), 0, true));
+        assert!(rule.matching(v6("2001:db8::42", 0), 0, true));
+    }
+
+    #[test]
+    fn ports_none_matches_everything() {
+        // No ports defined → every port / protocol should be accepted.
+        let rule = AclRule {
+            addr: AclAddress::Any,
+            ports: None,
+            outbound: "default".parse().unwrap(),
+            hijack: None,
+        };
+
+        for port in [0u16, 22, 80, 443, 65535] {
+            assert!(rule.matching(v4("1.2.3.4", port), port, true));
+            assert!(rule.matching(v4("1.2.3.4", port), port, false));
+        }
+    }
+
+    #[test]
+    fn single_port_without_protocol() {
+        // Accept only port 8080, protocol‑agnostic.
+        let ports = AclPorts {
+            entries: vec![AclPortEntry {
+                protocol: None,
+                port_spec: AclPortSpec::Single(8080),
+            }],
+        };
+
+        let rule = AclRule {
+            addr: AclAddress::Any,
+            ports: Some(ports),
+            outbound: "default".parse().unwrap(),
+            hijack: None,
+        };
+
+        assert!(rule.matching(v4("10.0.0.1", 8080), 8080, true));
+        assert!(rule.matching(v4("10.0.0.1", 8080), 8080, false));
+        // Anything else must be rejected.
+        assert!(!rule.matching(v4("10.0.0.1", 80), 80, true));
+        assert!(!rule.matching(v4("10.0.0.1", 443), 443, false));
+    }
+
+    #[test]
+    fn port_range_with_protocol() {
+        // Allow TCP ports 1000‑1005, UDP ports 2000‑2002.
+        let ports = AclPorts {
+            entries: vec![
+                AclPortEntry {
+                    protocol: Some(AclProtocol::Tcp),
+                    port_spec: AclPortSpec::Range(1000, 1005),
+                },
+                AclPortEntry {
+                    protocol: Some(AclProtocol::Udp),
+                    port_spec: AclPortSpec::Range(2000, 2002),
+                },
+            ],
+        };
+
+        let rule = AclRule {
+            addr: AclAddress::Any,
+            ports: Some(ports),
+            outbound: "default".parse().unwrap(),
+            hijack: None,
+        };
+
+        // TCP inside range → ok
+        assert!(rule.matching(v4("8.8.8.8", 1003), 1003, true));
+        // TCP outside range → reject
+        assert!(!rule.matching(v4("8.8.8.8", 999), 999, true));
+
+        // UDP inside range → ok
+        assert!(rule.matching(v4("8.8.8.8", 2001), 2001, false));
+        // UDP outside range → reject
+        assert!(!rule.matching(v4("8.8.8.8", 1999), 1999, false));
+    }
+
+    #[test]
+    fn address_and_port_combination() {
+        // Only allow TCP 22 to 192.0.2.10, everything else is blocked.
+        let ports = AclPorts {
+            entries: vec![AclPortEntry {
+                protocol: Some(AclProtocol::Tcp),
+                port_spec: AclPortSpec::Single(22),
+            }],
+        };
+
+        let rule = AclRule {
+            addr: AclAddress::Ip("192.0.2.10".into()),
+            ports: Some(ports),
+            outbound: "default".parse().unwrap(),
+            hijack: None,
+        };
+
+        // Matching address, matching port, matching protocol → true
+        assert!(rule.matching(v4("192.0.2.10", 22), 22, true));
+
+        // Wrong address
+        assert!(!rule.matching(v4("192.0.2.11", 22), 22, true));
+
+        // Right address, wrong port
+        assert!(!rule.matching(v4("192.0.2.10", 23), 23, true));
+
+        // Right address & port but UDP → rejected because protocol is TCP‑only
+        assert!(!rule.matching(v4("192.0.2.10", 22), 22, false));
+    }
+
+    #[test]
+    fn ports_defined_but_protocol_mismatch_results_in_rejection() {
+        // Rule says “tcp/443”.  We ask for the same port but UDP → must be rejected.
+        let ports = AclPorts {
+            entries: vec![AclPortEntry {
+                protocol: Some(AclProtocol::Tcp),
+                port_spec: AclPortSpec::Single(443),
+            }],
+        };
+
+        let rule = AclRule {
+            addr: AclAddress::Any,
+            ports: Some(ports),
+            outbound: "default".parse().unwrap(),
+            hijack: None,
+        };
+
+        // UDP request → false
+        assert!(!rule.matching(v4("1.1.1.1", 443), 443, false));
+
+        // TCP request → true
+        assert!(rule.matching(v4("1.1.1.1", 443), 443, true));
+    }
+
+    #[test]
+    fn empty_allowed_port_set_is_rejected() {
+        // A rule with a port entry that is filtered out by protocol should reject
+        // everything, even if the address matches.
+        let ports = AclPorts {
+            entries: vec![AclPortEntry {
+                protocol: Some(AclProtocol::Tcp), // only TCP allowed
+                port_spec: AclPortSpec::Single(9999),
+            }],
+        };
+
+        let rule = AclRule {
+            addr: AclAddress::Any,
+            ports: Some(ports),
+            outbound: "default".parse().unwrap(),
+            hijack: None,
+        };
+
+        // UDP request – the only entry is filtered out → false
+        assert!(!rule.matching(v4("8.8.8.8", 9999), 9999, false));
+    }
+}

--- a/tuic-server/src/config.rs
+++ b/tuic-server/src/config.rs
@@ -534,7 +534,7 @@ impl<'de> Deserialize<'de> for AclRule {
         let addr = helper.addr.parse::<AclAddress>().map_err(|e| {
             de::Error::invalid_value(
                 Unexpected::Str(&helper.addr),
-                &format!("valid address: {}", e).as_str(),
+                &format!("valid address: {e}").as_str(),
             )
         })?;
 
@@ -542,7 +542,7 @@ impl<'de> Deserialize<'de> for AclRule {
             Some(ports_str.parse::<AclPorts>().map_err(|e| {
                 de::Error::invalid_value(
                     Unexpected::Str(&ports_str),
-                    &format!("valid ports: {}", e).as_str(),
+                    &format!("valid ports: {e}").as_str(),
                 )
             })?)
         } else {

--- a/tuic-server/src/connection/handle_task.rs
+++ b/tuic-server/src/connection/handle_task.rs
@@ -7,7 +7,7 @@ use std::{
 use bytes::Bytes;
 use eyre::{OptionExt, eyre};
 use tokio::{
-    io::AsyncWriteExt,
+    io::{AsyncReadExt, AsyncWriteExt},
     net::{self, TcpSocket, TcpStream},
 };
 use tracing::{info, warn};
@@ -16,6 +16,7 @@ use tuic_quinn::{Authenticate, Connect, Packet};
 
 use super::{Connection, ERROR_CODE, UdpSession};
 use crate::{
+    config::OutboundRule,
     error::Error,
     io::exchange_tcp,
     restful,
@@ -23,31 +24,136 @@ use crate::{
 };
 
 impl Connection {
-    fn get_bind_ip(&self, is_ipv6: bool) -> Option<IpAddr> {
-        if is_ipv6 {
-            self.ctx.cfg.outbound.default.bind_ipv6.map(IpAddr::from)
+    fn select_outbound_rule<'a>(&'a self, name: &str) -> &'a OutboundRule {
+        if name.eq_ignore_ascii_case("default") || name.eq_ignore_ascii_case("direct") {
+            &self.ctx.cfg.outbound.default
         } else {
-            self.ctx.cfg.outbound.default.bind_ipv4.map(IpAddr::from)
+            self.ctx
+                .cfg
+                .outbound
+                .named
+                .get(name)
+                .unwrap_or(&self.ctx.cfg.outbound.default)
         }
     }
 
-    fn create_socket(&self, target_addr: &SocketAddr) -> std::io::Result<TcpSocket> {
+    fn decide_acl_for_addrs(
+        &self,
+        addrs: &[SocketAddr],
+        port: u16,
+        is_tcp: bool,
+        domain: Option<&str>,
+    ) -> (String, Option<IpAddr>, bool) {
+        // Returns (outbound_name, hijack_ip, drop)
+
+        use crate::acl::{AclAddress, AclPortSpec, AclProtocol};
+
+        // Helper: port/protocol matching
+        let ports_proto_ok = |rule: &crate::acl::AclRule| -> bool {
+            if let Some(ports) = &rule.ports {
+                use std::collections::HashSet;
+                let mut allowed: HashSet<(u16, Option<AclProtocol>)> = HashSet::new();
+                for entry in &ports.entries {
+                    let proto_ok = match entry.protocol {
+                        Some(AclProtocol::Tcp) => is_tcp,
+                        Some(AclProtocol::Udp) => !is_tcp,
+                        None => true,
+                    };
+                    if !proto_ok {
+                        continue;
+                    }
+                    match entry.port_spec {
+                        AclPortSpec::Single(p) => {
+                            allowed.insert((p, entry.protocol.clone()));
+                        }
+                        AclPortSpec::Range(start, end) => {
+                            for p in start..=end {
+                                allowed.insert((p, entry.protocol.clone()));
+                            }
+                        }
+                    }
+                }
+                if allowed.is_empty() {
+                    return false;
+                }
+                allowed.iter().any(|&(p, _)| p == port)
+            } else {
+                true
+            }
+        };
+
+        // Helper: domain and wildcard matching
+        let domain_matches = |addr: &AclAddress, dom: &str| -> bool {
+            match addr {
+                AclAddress::Domain(d) => d.eq_ignore_ascii_case(dom),
+                AclAddress::WildcardDomain(pattern) => {
+                    let stripped = if let Some(rest) = pattern.strip_prefix("*.") {
+                        rest
+                    } else if let Some(rest) = pattern.strip_prefix("suffix:") {
+                        rest
+                    } else {
+                        pattern.as_str()
+                    };
+                    let dom_l = dom.to_ascii_lowercase();
+                    let suf_l = stripped.to_ascii_lowercase();
+                    dom_l == suf_l || dom_l.ends_with(&format!(".{}", suf_l))
+                }
+                _ => false,
+            }
+        };
+
+        for rule in &self.ctx.cfg.acl {
+            let matched = if let Some(dom) = domain {
+                match &rule.addr {
+                    AclAddress::Domain(_) | AclAddress::WildcardDomain(_) => {
+                        domain_matches(&rule.addr, dom) && ports_proto_ok(rule)
+                    }
+                    _ => addrs.iter().any(|sa| rule.matching(*sa, port, is_tcp)),
+                }
+            } else {
+                addrs.iter().any(|sa| rule.matching(*sa, port, is_tcp))
+            };
+
+            if matched {
+                let hijack = rule.hijack.as_ref().and_then(|h| h.parse::<IpAddr>().ok());
+                if rule.outbound.eq_ignore_ascii_case("drop") {
+                    return ("drop".to_string(), hijack, true);
+                }
+                return (rule.outbound.clone(), hijack, false);
+            }
+        }
+        // Built-in safety: drop localhost if no explicit rule matched
+        let is_loopback = addrs.iter().any(|sa| match sa.ip() {
+            IpAddr::V4(v4) => v4.is_loopback(),
+            IpAddr::V6(v6) => v6.is_loopback(),
+        });
+        if is_loopback {
+            return ("drop".to_string(), None, true);
+        }
+        ("default".to_string(), None, false)
+    }
+
+    fn get_bind_ip(&self, is_ipv6: bool, outbound: &OutboundRule) -> Option<IpAddr> {
+        if is_ipv6 {
+            outbound.bind_ipv6.map(IpAddr::from)
+        } else {
+            outbound.bind_ipv4.map(IpAddr::from)
+        }
+    }
+
+    fn create_socket(
+        &self,
+        target_addr: &SocketAddr,
+        outbound: &OutboundRule,
+    ) -> std::io::Result<TcpSocket> {
         let socket = if target_addr.is_ipv4() {
             TcpSocket::new_v4()?
         } else {
             TcpSocket::new_v6()?
         };
         #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
-        socket.bind_device(
-            self.ctx
-                .cfg
-                .outbound
-                .default
-                .bind_device
-                .as_ref()
-                .map(|s| s.as_bytes()),
-        )?;
-        if let Some(bind_ip) = self.get_bind_ip(target_addr.is_ipv6()) {
+        socket.bind_device(outbound.bind_device.as_ref().map(|s| s.as_bytes()))?;
+        if let Some(bind_ip) = self.get_bind_ip(target_addr.is_ipv6(), outbound) {
             socket.bind(SocketAddr::new(bind_ip, 0))?;
         }
 
@@ -75,9 +181,46 @@ impl Connection {
         );
 
         let process = async {
-            // Resolve DNS and collect all addresses.
-            let addrs = self.resolve_and_filter_addresses(conn.addr()).await?;
-            let mut stream = self.connect_to_addresses(addrs).await?;
+            // First resolve using default outbound to get candidate IPs
+            let default_outbound = &self.ctx.cfg.outbound.default;
+            let initial_addrs = self
+                .resolve_and_filter_addresses(conn.addr(), default_outbound, None)
+                .await?;
+
+            // Decide ACL based on resolved addresses
+            let port = conn.addr().port();
+            let domain = match conn.addr() {
+                Address::DomainAddress(d, _) => Some(d.as_str()),
+                _ => None,
+            };
+            let (outbound_name, hijack, drop) =
+                self.decide_acl_for_addrs(&initial_addrs, port, true, domain);
+
+            if drop {
+                warn!(
+                    "[{id:#010x}] [{addr}] [{user}] [TCP] {target_addr} blocked by ACL",
+                    id = self.id(),
+                    addr = self.inner.remote_address(),
+                    user = self.auth,
+                );
+                _ = conn.reset(ERROR_CODE);
+                return Ok(());
+            }
+
+            // Select outbound rule
+            let outbound = self.select_outbound_rule(&outbound_name);
+
+            // Establish connection according to outbound type
+            let mut stream = if outbound.kind.eq_ignore_ascii_case("socks5") {
+                self.connect_via_socks5(outbound, conn.addr(), hijack)
+                    .await?
+            } else {
+                // Resolve again if outbound/ip_mode differs or hijack is requested
+                let addrs = self
+                    .resolve_and_filter_addresses(conn.addr(), outbound, hijack)
+                    .await?;
+                self.connect_to_addresses(addrs, outbound).await?
+            };
 
             stream.set_nodelay(true)?;
 
@@ -114,10 +257,22 @@ impl Connection {
         }
     }
 
-    async fn resolve_and_filter_addresses(&self, addr: &Address) -> eyre::Result<Vec<SocketAddr>> {
+    async fn resolve_and_filter_addresses(
+        &self,
+        addr: &Address,
+        outbound: &OutboundRule,
+        hijack: Option<IpAddr>,
+    ) -> eyre::Result<Vec<SocketAddr>> {
+        // If hijack is specified, bypass DNS and use hijack IP with original port
+        if let Some(hijack_ip) = hijack {
+            let port = addr.port();
+            let sa = SocketAddr::new(hijack_ip, port);
+            return Ok(vec![sa]);
+        }
+
         let mut addrs: Vec<SocketAddr> = resolve_dns(addr).await?.collect();
 
-        match self.ctx.cfg.outbound.default.ip_mode.unwrap() {
+        match outbound.ip_mode.unwrap_or(IpMode::Auto) {
             IpMode::PreferV4 => {
                 addrs.sort_by_key(|a| !a.is_ipv4());
             }
@@ -140,11 +295,15 @@ impl Connection {
         Ok(addrs)
     }
 
-    async fn connect_to_addresses(&self, addrs: Vec<SocketAddr>) -> eyre::Result<TcpStream> {
+    async fn connect_to_addresses(
+        &self,
+        addrs: Vec<SocketAddr>,
+        outbound: &OutboundRule,
+    ) -> eyre::Result<TcpStream> {
         let mut last_error = None;
 
         for addr in addrs {
-            match self.create_socket(&addr) {
+            match self.create_socket(&addr, outbound) {
                 Ok(socket) => match socket.connect(addr).await {
                     Ok(stream) => return Ok(stream),
                     Err(err) => last_error = Some(err),
@@ -216,12 +375,80 @@ impl Connection {
                 },
             };
 
-            let Some(socket_addr) = resolve_dns(&addr).await?.next() else {
+            // Resolve using default outbound and apply ACL
+            let initial_addrs: Vec<SocketAddr> = resolve_dns(&addr).await?.collect();
+            if initial_addrs.is_empty() {
                 return Err(Error::from(IoError::new(
                     ErrorKind::NotFound,
                     "no address resolved",
                 )));
+            }
+
+            let domain = match &addr {
+                Address::DomainAddress(d, _) => Some(d.as_str()),
+                _ => None,
             };
+            let (outbound_name, hijack, should_drop) =
+                self.decide_acl_for_addrs(&initial_addrs, addr.port(), false, domain);
+            if should_drop {
+                // Silently drop the packet as per ACL
+                warn!(
+                    "[{id:#010x}] [{addr}] [{user}] [UDP-OUT] [{assoc_id:#06x}] [from-{mode}] \
+                     [{pkt_id:#06x}] to {src_addr} blocked by ACL",
+                    id = self.id(),
+                    addr = self.inner.remote_address(),
+                    user = self.auth,
+                    src_addr = addr,
+                );
+                return Ok(());
+            }
+
+            // Evaluate outbound policy for UDP
+            let outbound = self.select_outbound_rule(&outbound_name);
+            if outbound.kind.eq_ignore_ascii_case("socks5") {
+                // Block UDP by default when a SOCKS5 outbound is selected, unless explicitly
+                // allowed
+                let allow_udp = outbound.allow_udp.unwrap_or(false);
+                if !allow_udp {
+                    warn!(
+                        "[{id:#010x}] [{addr}] [{user}] [UDP-OUT-SOCKS5] [{assoc_id:#06x}] \
+                         [from-{mode}] [{pkt_id:#06x}] to {src_addr} blocked by ACL",
+                        id = self.id(),
+                        addr = self.inner.remote_address(),
+                        user = self.auth,
+                        src_addr = addr,
+                    );
+                    // Silently drop UDP to avoid leaking QUIC/HTTP3 when SOCKS5 is requested
+                    return Ok(());
+                } else {
+                    // We don't support UDP via SOCKS5 yet; fall back to direct
+                    info!(
+                        "[{id:#010x}] [{addr}] [{user}] [UDP-OUT] [{assoc_id:#06x}] outbound \
+                         '{outbound_name}' allows UDP but UDP via SOCKS5 not supported; using \
+                         direct as you configured",
+                        id = self.id(),
+                        addr = self.inner.remote_address(),
+                        user = self.auth,
+                    );
+                }
+            } else if !outbound.kind.eq_ignore_ascii_case("direct") {
+                // Outbound other than direct is not supported for UDP yet; proceed as direct
+                warn!(
+                    "[{id:#010x}] [{addr}] [{user}] [UDP-OUT] [{assoc_id:#06x}] outbound \
+                     '{outbound_name}' not supported; using direct",
+                    id = self.id(),
+                    addr = self.inner.remote_address(),
+                    user = self.auth,
+                );
+            }
+
+            let socket_addr = if let Some(h) = hijack {
+                SocketAddr::new(h, addr.port())
+            } else {
+                // Use the first address resolved
+                initial_addrs[0]
+            };
+
             let uuid = self
                 .auth
                 .get()
@@ -316,5 +543,149 @@ async fn resolve_dns(addr: &Address) -> Result<impl Iterator<Item = SocketAddr>,
             .collect::<Vec<_>>()
             .into_iter()),
         Address::SocketAddress(addr) => Ok(vec![*addr].into_iter()),
+    }
+}
+
+impl Connection {
+    async fn connect_via_socks5(
+        &self,
+        outbound: &OutboundRule,
+        target: &Address,
+        hijack: Option<IpAddr>,
+    ) -> eyre::Result<TcpStream> {
+        // 1) Resolve and connect to the SOCKS5 proxy
+        let proxy_addr = outbound
+            .addr
+            .as_ref()
+            .ok_or_else(|| eyre!("socks5 outbound requires 'addr'"))?;
+        let proxy_addrs: Vec<SocketAddr> = net::lookup_host(proxy_addr.as_str()).await?.collect();
+        if proxy_addrs.is_empty() {
+            return Err(eyre!(
+                "No addresses resolved for SOCKS5 proxy: {proxy_addr}"
+            ));
+        }
+        let mut stream = self.connect_to_addresses(proxy_addrs, outbound).await?;
+
+        // 2) Greeting / Method selection
+        let (has_userpass, username, password) = match (&outbound.username, &outbound.password) {
+            (Some(u), Some(p)) => (true, Some(u.as_bytes()), Some(p.as_bytes())),
+            (None, None) => (false, None, None),
+            _ => {
+                return Err(eyre!(
+                    "invalid socks5 auth config: username/password must be both set or both \
+                     omitted"
+                ));
+            }
+        };
+
+        if has_userpass {
+            // Offer both: NoAuth(0x00) and User/Pass(0x02)
+            let greet = [0x05u8, 0x02, 0x00, 0x02];
+            stream.write_all(&greet).await?;
+        } else {
+            let greet = [0x05u8, 0x01, 0x00];
+            stream.write_all(&greet).await?;
+        }
+        let mut resp = [0u8; 2];
+        stream.read_exact(&mut resp).await?;
+        if resp[0] != 0x05 {
+            return Err(eyre!(
+                "invalid socks5 version in method selection: {}",
+                resp[0]
+            ));
+        }
+        let method = resp[1];
+        if method == 0xFF {
+            return Err(eyre!("socks5 proxy has no acceptable auth methods"));
+        }
+
+        // 3) Username/Password sub-negotiation if required
+        if method == 0x02 {
+            let u = username.unwrap();
+            let p = password.unwrap();
+            if u.len() > 255 || p.len() > 255 {
+                return Err(eyre!("socks5 username/password too long"));
+            }
+            let mut buf = Vec::with_capacity(3 + u.len() + p.len());
+            buf.push(0x01); // subnegotiation version
+            buf.push(u.len() as u8);
+            buf.extend_from_slice(u);
+            buf.push(p.len() as u8);
+            buf.extend_from_slice(p);
+            stream.write_all(&buf).await?;
+            let mut auth_resp = [0u8; 2];
+            stream.read_exact(&mut auth_resp).await?;
+            if auth_resp[0] != 0x01 || auth_resp[1] != 0x00 {
+                return Err(eyre!(
+                    "socks5 username/password auth failed (code={})",
+                    auth_resp[1]
+                ));
+            }
+        }
+
+        // 4) CONNECT request to target
+        let (atyp, addr_bytes, port): (u8, Vec<u8>, u16) = if let Some(ip) = hijack {
+            match ip {
+                std::net::IpAddr::V4(v4) => (0x01, v4.octets().to_vec(), target.port()),
+                std::net::IpAddr::V6(v6) => (0x04, v6.octets().to_vec(), target.port()),
+            }
+        } else {
+            match target {
+                Address::DomainAddress(domain, port) => {
+                    if domain.len() > 255 {
+                        return Err(eyre!("domain name too long for socks5: {}", domain));
+                    }
+                    let mut v = Vec::with_capacity(1 + domain.len());
+                    v.push(domain.len() as u8);
+                    v.extend_from_slice(domain.as_bytes());
+                    (0x03, v, *port)
+                }
+                Address::SocketAddress(sa) => match sa {
+                    SocketAddr::V4(v4) => (0x01, v4.ip().octets().to_vec(), v4.port()),
+                    SocketAddr::V6(v6) => (0x04, v6.ip().octets().to_vec(), v6.port()),
+                },
+                Address::None => return Err(eyre!("invalid target address for CONNECT: none")),
+            }
+        };
+
+        let mut req = Vec::with_capacity(4 + addr_bytes.len() + 2);
+        req.push(0x05); // version
+        req.push(0x01); // CONNECT
+        req.push(0x00); // RSV
+        req.push(atyp);
+        req.extend_from_slice(&addr_bytes);
+        req.push((port >> 8) as u8);
+        req.push((port & 0xFF) as u8);
+        stream.write_all(&req).await?;
+
+        // 5) Read CONNECT reply
+        let mut hdr = [0u8; 4];
+        stream.read_exact(&mut hdr).await?;
+        if hdr[0] != 0x05 {
+            return Err(eyre!("invalid socks5 version in reply: {}", hdr[0]));
+        }
+        if hdr[1] != 0x00 {
+            return Err(eyre!("socks5 connect failed, reply code={}", hdr[1]));
+        }
+        let atyp = hdr[3];
+        match atyp {
+            0x01 => {
+                let mut rest = [0u8; 6];
+                stream.read_exact(&mut rest).await?;
+            }
+            0x03 => {
+                let mut len = [0u8; 1];
+                stream.read_exact(&mut len).await?;
+                let mut skip = vec![0u8; len[0] as usize + 2];
+                stream.read_exact(&mut skip).await?;
+            }
+            0x04 => {
+                let mut rest = [0u8; 18];
+                stream.read_exact(&mut rest).await?;
+            }
+            _ => return Err(eyre!("invalid socks5 ATYP in reply: {}", atyp)),
+        }
+
+        Ok(stream)
     }
 }

--- a/tuic-server/src/connection/handle_task.rs
+++ b/tuic-server/src/connection/handle_task.rs
@@ -96,7 +96,7 @@ impl Connection {
                     };
                     let dom_l = dom.to_ascii_lowercase();
                     let suf_l = stripped.to_ascii_lowercase();
-                    dom_l == suf_l || dom_l.ends_with(&format!(".{}", suf_l))
+                    dom_l == suf_l || dom_l.ends_with(&format!(".{suf_l}"))
                 }
                 _ => false,
             }

--- a/tuic-server/src/connection/handle_task.rs
+++ b/tuic-server/src/connection/handle_task.rs
@@ -64,11 +64,11 @@ impl Connection {
                     }
                     match entry.port_spec {
                         AclPortSpec::Single(p) => {
-                            allowed.insert((p, entry.protocol.clone()));
+                            allowed.insert((p, entry.protocol));
                         }
                         AclPortSpec::Range(start, end) => {
                             for p in start..=end {
-                                allowed.insert((p, entry.protocol.clone()));
+                                allowed.insert((p, entry.protocol));
                             }
                         }
                     }

--- a/tuic-server/src/main.rs
+++ b/tuic-server/src/main.rs
@@ -6,6 +6,7 @@ use tracing_subscriber::{fmt::time::LocalTime, layer::SubscriberExt, util::Subsc
 
 use crate::{old_config::ConfigError, server::Server};
 
+mod acl;
 mod config;
 mod connection;
 mod error;

--- a/tuic/src/protocol/mod.rs
+++ b/tuic/src/protocol/mod.rs
@@ -113,8 +113,9 @@ impl Header {
 /// fragment of a UDP packet.
 ///
 /// The port number is encoded in 2 bytes after the Domain name / IP address.
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Default)]
 pub enum Address {
+    #[default]
     None,
     DomainAddress(String, u16),
     SocketAddress(SocketAddr),
@@ -190,11 +191,5 @@ impl Display for Address {
             Self::DomainAddress(addr, port) => write!(f, "{addr}:{port}"),
             Self::SocketAddress(addr) => write!(f, "{addr}"),
         }
-    }
-}
-
-impl Default for Address {
-    fn default() -> Self {
-        Self::None
     }
 }

--- a/tuic/src/protocol/mod.rs
+++ b/tuic/src/protocol/mod.rs
@@ -173,6 +173,14 @@ impl Address {
     pub fn is_ipv6(&self) -> bool {
         matches!(self, Self::SocketAddress(SocketAddr::V6(_)))
     }
+
+    pub fn port(&self) -> u16 {
+        match self {
+            Self::None => 0u16,
+            Self::DomainAddress(_, port) => *port,
+            Self::SocketAddress(addr) => addr.port(),
+        }
+    }
 }
 
 impl Display for Address {


### PR DESCRIPTION
Altough you suggest me to contribute to [wind](https://github.com/proxy-rs/wind/) in the [previous PR](https://github.com/Itsusinn/tuic/pull/60),
I think this PR is crucial as it fixes a security pitfall of tuic.

Also, this implements SOCKS5 outbound, which is marked as TODO in the previous PR.

This PR includes:

* Can configure ACL of tuic-server's outbound. See server's README.md for more.
The syntax is inspired by [Hysteria](https://v2.hysteria.network/docs/advanced/ACL/)
* The default outbound ACL will REJECT access to server's localhost. 
Currently, Tuic allows the client to access services not publicly exposed(i.e. bind to 127.0.0.1 / ::1) on the server. However, users having access to Tuic are not necessarily supposed to have SSH access to server, thus, this may lead to unwanted and unaware intrusions into local services.
To expose services on the server to client users deliberately, explicitly whitelist those ports or use '*' to allow access to all ports on localhost.
* implement SOCKS5 outbound

I think after this PR, Tuic's outbound and ACL feature is on par with Hysteria.