### PR TITLE
fix: copy_io is a large future, this will result in a large number of memory copies

### DIFF
--- a/tuic-server/src/io.rs
+++ b/tuic-server/src/io.rs
@@ -58,3 +58,78 @@ where
 
 	(a2b_num, b2a_num, last_err)
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[tokio::test]
+	async fn test_copy_io_bidirectional() {
+		// Create two duplex streams: client-side and server-side
+		let (mut client_a, mut client_b) = tokio::io::duplex(1024);
+		let (mut server_a, mut server_b) = tokio::io::duplex(1024);
+
+		let data_to_server = b"Request from client";
+		let data_to_client = b"Response from server";
+
+		// Spawn copy_io to connect the two streams
+		let copy_task = tokio::spawn(async move { copy_io(&mut client_b, &mut server_b).await });
+
+		// Write from client side
+		client_a.write_all(data_to_server).await.unwrap();
+
+		// Write from server side
+		server_a.write_all(data_to_client).await.unwrap();
+
+		// Read on client side (should receive data from server)
+		let mut client_buf = vec![0u8; data_to_client.len()];
+		client_a.read_exact(&mut client_buf).await.unwrap();
+
+		// Read on server side (should receive data from client)
+		let mut server_buf = vec![0u8; data_to_server.len()];
+		server_a.read_exact(&mut server_buf).await.unwrap();
+
+		assert_eq!(&client_buf, data_to_client);
+		assert_eq!(&server_buf, data_to_server);
+
+		// Close both ends
+		drop(client_a);
+		drop(server_a);
+
+		let (a2b_count, b2a_count, err) = copy_task.await.unwrap();
+
+		assert!(err.is_none());
+		assert_eq!(a2b_count, data_to_server.len());
+		assert_eq!(b2a_count, data_to_client.len());
+	}
+
+	#[tokio::test]
+	async fn test_copy_io_one_direction() {
+		// Create two duplex streams
+		let (mut left_a, mut left_b) = tokio::io::duplex(1024);
+		let (mut right_a, mut right_b) = tokio::io::duplex(1024);
+
+		let test_data = b"Hello, world!";
+
+		// Spawn copy_io to connect the streams
+		let copy_task = tokio::spawn(async move { copy_io(&mut left_b, &mut right_b).await });
+
+		// Write from left side
+		left_a.write_all(test_data).await.unwrap();
+
+		// Read from right side
+		let mut buf = vec![0u8; test_data.len()];
+		right_a.read_exact(&mut buf).await.unwrap();
+
+		assert_eq!(&buf, test_data);
+
+		// Close streams
+		drop(left_a);
+		drop(right_a);
+
+		let (a2b_count, b2a_count, _err) = copy_task.await.unwrap();
+
+		assert_eq!(a2b_count, test_data.len());
+		assert_eq!(b2a_count, 0);
+	}
+}


### PR DESCRIPTION
I wrote a simple test, but I won't put it in the source code because the benchmark framework hasn't been introduced yet.

```rs
use std::time::Instant;

use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};

const BUFFER_SIZE: usize = 16 * 1024;
const TEST_DATA_SIZE: usize = 10 * 1024 * 1024 * 1024; // 100 MB
const NUM_ITERATIONS: usize = 10000;
const CONCURRENT_CONNECTIONS: usize = 1_000_000;

/// Stack-based version (current implementation)
async fn copy_io_stack<A, B>(a: &mut A, b: &mut B) -> (usize, usize, Option<std::io::Error>)
where
	A: AsyncRead + AsyncWrite + Unpin + ?Sized,
	B: AsyncRead + AsyncWrite + Unpin + ?Sized,
{
	let mut a2b = [0u8; BUFFER_SIZE];
	let mut b2a = [0u8; BUFFER_SIZE];

	let mut a2b_num = 0;
	let mut b2a_num = 0;
	let mut last_err = None;

	loop {
		tokio::select! {
			a2b_res = a.read(&mut a2b) => match a2b_res {
				Ok(num) => {
					if num == 0 {
						break;
					}
					a2b_num += num;
					if let Err(err) = b.write_all(&a2b[..num]).await {
						last_err = Some(err);
						break;
					}
				},
				Err(err) => {
					last_err = Some(err);
					break;
				}
			},
			b2a_res = b.read(&mut b2a) => match b2a_res {
				Ok(num) => {
					if num == 0 {
						break;
					}
					b2a_num += num;
					if let Err(err) = a.write_all(&b2a[..num]).await {
						last_err = Some(err);
						break;
					}
				},
				Err(err) => {
					last_err = Some(err);
					break;
				},
			}
		}
	}

	(a2b_num, b2a_num, last_err)
}

/// Box-based version (heap allocation - 2 separate allocations)
async fn copy_io_box<A, B>(a: &mut A, b: &mut B) -> (usize, usize, Option<std::io::Error>)
where
	A: AsyncRead + AsyncWrite + Unpin + ?Sized,
	B: AsyncRead + AsyncWrite + Unpin + ?Sized,
{
	let mut a2b = vec![0u8; BUFFER_SIZE].into_boxed_slice();
	let mut b2a = vec![0u8; BUFFER_SIZE].into_boxed_slice();

	let mut a2b_num = 0;
	let mut b2a_num = 0;
	let mut last_err = None;

	loop {
		tokio::select! {
			a2b_res = a.read(&mut a2b) => match a2b_res {
				Ok(num) => {
					if num == 0 {
						break;
					}
					a2b_num += num;
					if let Err(err) = b.write_all(&a2b[..num]).await {
						last_err = Some(err);
						break;
					}
				},
				Err(err) => {
					last_err = Some(err);
					break;
				}
			},
			b2a_res = b.read(&mut b2a) => match b2a_res {
				Ok(num) => {
					if num == 0 {
						break;
					}
					b2a_num += num;
					if let Err(err) = a.write_all(&b2a[..num]).await {
						last_err = Some(err);
						break;
					}
				},
				Err(err) => {
					last_err = Some(err);
					break;
				},
			}
		}
	}

	(a2b_num, b2a_num, last_err)
}

// Concurrent benchmark functions
async fn spawn_copy_stack() {
	let (mut client, mut server) = tokio::io::duplex(8 * 1024);

	tokio::spawn(async move {
		let _ = client.write_all(&[0u8; 1024]).await;
		let _ = client.shutdown().await;
	});

	let mut dummy = tokio::io::empty();
	let _ = copy_io_stack(&mut server, &mut dummy).await;
}

async fn spawn_copy_box() {
	let (mut client, mut server) = tokio::io::duplex(8 * 1024);

	tokio::spawn(async move {
		let _ = client.write_all(&[0u8; 1024]).await;
		let _ = client.shutdown().await;
	});

	let mut dummy = tokio::io::empty();
	let _ = copy_io_box(&mut server, &mut dummy).await;
}

async fn benchmark_concurrent<F, Fut>(name: &str, spawn_fn: F) -> std::time::Duration
where
	F: Fn() -> Fut,
	Fut: std::future::Future<Output = ()> + Send + 'static,
{
	let start = Instant::now();

	let mut handles = Vec::with_capacity(CONCURRENT_CONNECTIONS);

	for _ in 0..CONCURRENT_CONNECTIONS {
		let fut = spawn_fn();
		handles.push(tokio::spawn(fut));
	}

	// Wait for all tasks to complete
	for handle in handles {
		let _ = handle.await;
	}

	let duration = start.elapsed();
	println!("  [{name}] {CONCURRENT_CONNECTIONS} concurrent connections completed in {duration:?}");
	duration
}

#[tokio::main]
async fn main() {
	println!("=== Copy IO Benchmark: Stack vs Box Allocation ===");
	println!("Buffer size: {} KB", BUFFER_SIZE / 1024);
	println!("Test data size: {} MB", TEST_DATA_SIZE / (1024 * 1024));
	println!("Iterations: {NUM_ITERATIONS}\n");

	// Run concurrent benchmarks
	println!("Running concurrent benchmarks...\n");

	let stack_concurrent = benchmark_concurrent("Stack", spawn_copy_stack).await;
	let box_concurrent = benchmark_concurrent("Box", spawn_copy_box).await;

	println!("\n=== Concurrent Results ===");
	println!("Stack:          {stack_concurrent:?}");
	println!("Box: {box_concurrent:?}");
}
```

result:

```
=== Copy IO Benchmark: Stack vs Box Allocation ===
Buffer size: 16 KB
Test data size: 10240 MB
Iterations: 10000

Running concurrent benchmarks...

  [Stack] 1000000 concurrent connections completed in 1.457541375s
  [Box] 1000000 concurrent connections completed in 818.383292ms

=== Concurrent Results ===
Stack:          1.457541375s
Box: 818.383292ms
```