### PR TITLE
feat(client): add lazy startup mode

### DIFF
--- a/tuic-client/README.md
+++ b/tuic-client/README.md
@@ -82,6 +82,12 @@ disable_sni = false
 # Connection timeout
 timeout = "8s"
 
+# Startup behavior:
+# "eager" -> connect on startup, exit on failure
+# "lazy"  -> (default) connect on first incoming SOCKS5/forward request, exit on failure
+# "loop"  -> connect on first incoming request, retry forever until success
+startup_mode = "lazy"
+
 # Heartbeat interval
 heartbeat = "3s"
 

--- a/tuic-client/src/config.rs
+++ b/tuic-client/src/config.rs
@@ -120,6 +120,9 @@ pub struct Relay {
 	#[serde(with = "humantime_serde")]
 	pub timeout: Duration,
 
+	#[educe(Default(expression = StartupMode::Lazy))]
+	pub startup_mode: StartupMode,
+
 	#[educe(Default(expression = Duration::from_secs(3)))]
 	#[serde(with = "humantime_serde")]
 	pub heartbeat: Duration,
@@ -158,6 +161,15 @@ pub struct Relay {
 
 	#[educe(Default = None)]
 	pub proxy: Option<ProxyConfig>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, serde::Serialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum StartupMode {
+	Eager,
+	#[default]
+	Lazy,
+	Loop,
 }
 
 #[derive(Debug, Deserialize, serde::Serialize, Educe, Clone, PartialEq, Eq)]
@@ -565,6 +577,7 @@ mod tests {
 		assert!(!config.relay.zero_rtt_handshake);
 		assert!(!config.relay.disable_sni);
 		assert_eq!(config.relay.timeout, Duration::from_secs(8));
+		assert_eq!(config.relay.startup_mode, StartupMode::Lazy);
 		assert_eq!(config.relay.heartbeat, Duration::from_secs(3));
 		assert!(!config.relay.disable_native_certs);
 		assert_eq!(config.relay.send_window, 16 * 1024 * 1024);
@@ -577,6 +590,41 @@ mod tests {
 		assert_eq!(config.relay.gc_lifetime, Duration::from_secs(15));
 		assert!(!config.relay.skip_cert_verify);
 		assert_eq!(config.local.max_packet_size, 1500);
+	}
+
+	#[test]
+	fn test_startup_mode_string_values() {
+		let json5_config = r#"
+		{
+			relay: {
+				server: "example.com:443",
+				uuid: "00000000-0000-0000-0000-000000000000",
+				password: "test",
+				startup_mode: "loop",
+			},
+			local: { server: "127.0.0.1:1080" },
+		}
+		"#;
+
+		let config = test_parse_config(json5_config, ".json5").unwrap();
+		assert_eq!(config.relay.startup_mode, StartupMode::Loop);
+	}
+
+	#[test]
+	fn test_startup_mode_eager() {
+		let toml_config = r#"
+		[relay]
+		server = "example.com:443"
+		uuid = "00000000-0000-0000-0000-000000000000"
+		password = "test"
+		startup_mode = "eager"
+
+		[local]
+		server = "127.0.0.1:1080"
+		"#;
+
+		let config = test_parse_config(toml_config, ".toml").unwrap();
+		assert_eq!(config.relay.startup_mode, StartupMode::Eager);
 	}
 	#[test]
 	fn test_tcp_udp_forward() {

--- a/tuic-client/src/lib.rs
+++ b/tuic-client/src/lib.rs
@@ -3,10 +3,17 @@
 
 use std::{
 	collections::HashMap,
-	sync::{Arc, atomic::AtomicU16},
+	sync::{
+		Arc,
+		atomic::{AtomicBool, AtomicU16, Ordering},
+	},
 };
 
-use tokio::sync::RwLock as AsyncRwLock;
+use tokio::{
+	sync::{Mutex as AsyncMutex, RwLock as AsyncRwLock},
+	time::{Duration, sleep},
+};
+use tracing::{error, warn};
 
 pub mod config;
 pub mod connection;
@@ -32,19 +39,68 @@ pub struct AppContext {
 	/// Next association ID counter for UDP forwarding (high bit set to avoid
 	/// collisions with SOCKS5 IDs)
 	pub next_fwd_assoc_id:   AtomicU16,
+	/// Startup connection behavior.
+	pub startup_mode:        config::StartupMode,
+	/// Whether the first relay connection has been established at least once.
+	pub first_connected:     AtomicBool,
+	/// Serializes first-connection logic under non-eager modes.
+	pub first_connect_lock:  AsyncMutex<()>,
 }
 
 impl AppContext {
 	/// Get or re-establish the TUIC relay connection.
 	pub async fn get_conn(&self) -> Result<connection::Connection, error::Error> {
-		self.conn_mgr
-			.get_conn(self.socks5_udp_sessions.clone(), self.fwd_udp_sessions.clone())
-			.await
+		if self.first_connected.load(Ordering::Relaxed) {
+			return self
+				.conn_mgr
+				.get_conn(self.socks5_udp_sessions.clone(), self.fwd_udp_sessions.clone())
+				.await;
+		}
+
+		let _guard = self.first_connect_lock.lock().await;
+		if self.first_connected.load(Ordering::Relaxed) {
+			return self
+				.conn_mgr
+				.get_conn(self.socks5_udp_sessions.clone(), self.fwd_udp_sessions.clone())
+				.await;
+		}
+
+		match self.startup_mode {
+			config::StartupMode::Eager | config::StartupMode::Lazy => {
+				let conn = self
+					.conn_mgr
+					.get_conn(self.socks5_udp_sessions.clone(), self.fwd_udp_sessions.clone())
+					.await
+					.unwrap_or_else(|err| {
+						error!("[relay] first on-demand connection failed: {err}");
+						std::process::exit(1);
+					});
+				self.first_connected.store(true, Ordering::Relaxed);
+				Ok(conn)
+			}
+			config::StartupMode::Loop => loop {
+				match self
+					.conn_mgr
+					.get_conn(self.socks5_udp_sessions.clone(), self.fwd_udp_sessions.clone())
+					.await
+				{
+					Ok(conn) => {
+						self.first_connected.store(true, Ordering::Relaxed);
+						return Ok(conn);
+					}
+					Err(err) => {
+						warn!("[relay] first on-demand connection failed in loop mode, retrying: {err}");
+						sleep(Duration::from_secs(1)).await;
+					}
+				}
+			},
+		}
 	}
 }
 
 /// Run the TUIC client with the given configuration.
 pub async fn run(cfg: Config) -> eyre::Result<()> {
+	let startup_mode = cfg.relay.startup_mode;
 	let conn_mgr = Arc::new(connection::ConnectionManager::build(cfg.relay).await?);
 	let socks5 = Arc::new(socks5::Server::new(
 		cfg.local.server,
@@ -59,10 +115,16 @@ pub async fn run(cfg: Config) -> eyre::Result<()> {
 		socks5_udp_sessions: Arc::new(AsyncRwLock::new(HashMap::new())),
 		fwd_udp_sessions: Arc::new(AsyncRwLock::new(HashMap::new())),
 		next_fwd_assoc_id: AtomicU16::new(0),
+		startup_mode,
+		first_connected: AtomicBool::new(false),
+		first_connect_lock: AsyncMutex::new(()),
 	});
 
-	// Establish the initial relay connection eagerly
-	ctx.get_conn().await?;
+	// Eager mode keeps the original behavior: connect at startup and exit on
+	// failure.
+	if matches!(startup_mode, config::StartupMode::Eager) {
+		ctx.get_conn().await?;
+	}
 
 	forward::start(ctx.clone(), cfg.local.tcp_forward, cfg.local.udp_forward).await;
 	socks5::Server::start(ctx.clone()).await;

--- a/tuic-client/src/main.rs
+++ b/tuic-client/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(ip)]
-
 use std::{process, str::FromStr};
 
 use chrono::{Offset, TimeZone};

--- a/tuic-tests/tests/integration_tests.rs
+++ b/tuic-tests/tests/integration_tests.rs
@@ -614,6 +614,7 @@ async fn test_ipv6_server_client_integration() -> eyre::Result<()> {
 			disable_sni:          true,
 			sni:                  None,
 			timeout:              Duration::from_secs(8),
+			startup_mode:         tuic_client::config::StartupMode::Lazy,
 			heartbeat:            Duration::from_secs(3),
 			disable_native_certs: true,
 			send_window:          8 * 1024 * 1024 * 2,


### PR DESCRIPTION
As requested by https://github.com/Itsusinn/tuic/issues/89 , this PR add lazy startup mode to client.
Unlike Hysteria's lazy mode, we have three modes: 
* "eager" -> connect on startup, exit on failure. 
Same startup behavior as before.
* "lazy"  -> connect on first incoming SOCKS5/forward request, exit on failure. 
Default to this as this reduces an unnecessary connection attempt on startup.
* "loop"  -> connect on first incoming request, retry forever until success. 
This is the same behavior as Hysteria's lazy mode. Will retry indefinitely even if the target address cannot be reached because it is incorrect.