### PR TITLE
feat(server): add HTTP/3 camouflage mode with reverse proxy support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [build]
-rustc-wrapper = "sccache"
+#rustc-wrapper = "sccache"
 
 [env]
 RUSTC_BOOTSTRAP = { value = "1" }

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
+[build]
+rustc-wrapper = "sccache"
+
 [env]
 RUSTC_BOOTSTRAP = { value = "1" }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
@@ -275,9 +275,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -286,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -298,9 +298,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
@@ -350,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef252edff26ddba56bbcdf2ee3307b8129acb86f5749b68990c168a6fcc9c76"
+checksum = "be44683b41ccb9ab2d23a5230015c9c3c55be97a25e4428366de8873103f7970"
 dependencies = [
  "axum",
  "axum-core",
@@ -395,9 +395,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -456,21 +456,15 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -492,7 +486,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -510,9 +504,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -532,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -550,9 +544,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -676,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.23.0"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -686,10 +680,11 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.23.0"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
 dependencies = [
+ "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -699,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.23.0"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core",
  "quote",
@@ -710,9 +705,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der-parser"
@@ -786,9 +781,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid",
@@ -921,15 +916,15 @@ dependencies = [
  "foldhash 0.2.0",
  "libm",
  "portable-atomic",
- "rand 0.9.2",
+ "rand 0.9.4",
  "siphasher",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "figment"
@@ -1164,7 +1159,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1213,9 +1208,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "headers"
@@ -1316,18 +1311,18 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.8"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8655f91cd07f2b9d0c24137bd650fe69617773435ee5ec83022377777ce65ef1"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1340,7 +1335,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1348,19 +1342,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -1412,12 +1405,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1425,9 +1419,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1438,9 +1432,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1452,15 +1446,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1472,15 +1466,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1516,9 +1510,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1532,12 +1526,12 @@ checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1565,9 +1559,9 @@ dependencies = [
 
 [[package]]
 name = "iri-string"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -1587,27 +1581,32 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror 2.0.18",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
 ]
 
 [[package]]
@@ -1641,10 +1640,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1690,9 +1691,9 @@ checksum = "803ec87c9cfb29b9d2633f20cba1f488db3fd53f2158b1024cbefb47ba05d413"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -1708,9 +1709,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1768,9 +1769,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -1966,8 +1967,10 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43fd2346a004ab7b18c468ad8f9554970a14872a701450155248ff5af73af53b"
 dependencies = [
- "futures-util",
+ "bytes",
  "pin-project-lite",
+ "smallvec",
+ "tokio",
 ]
 
 [[package]]
@@ -2036,12 +2039,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "piper"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2074,9 +2071,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2130,14 +2127,14 @@ dependencies = [
 
 [[package]]
 name = "qlog"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16689c500fede96aa7d5e1f8924abe08fafb65146d7e192826bb5fb57a1e1ad0"
+checksum = "13932f4f3e6b912a43b3af40a3174614b8408c85059b79ef23fe1b3c87e5d04a"
 dependencies = [
+ "humantime",
  "serde",
  "serde_json",
  "serde_with",
- "smallvec",
 ]
 
 [[package]]
@@ -2163,7 +2160,7 @@ dependencies = [
 [[package]]
 name = "quinn"
 version = "0.12.0"
-source = "git+https://github.com/Tipuch/quinn.git?branch=bbrv3#3896e5b27db244e40f9d1ea5c46f2d4c46f5c8aa"
+source = "git+https://github.com/Tipuch/quinn.git?branch=bbrv3#ce60e5b5c115db2a6053f4e0ca7fc52103cb76b9"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -2183,11 +2180,11 @@ dependencies = [
 [[package]]
 name = "quinn-congestions"
 version = "0.1.0"
-source = "git+https://github.com/proxy-rs/quinn-congestions.git#416b35d94612108f89e329444e7c4f9b4e47fe12"
+source = "git+https://github.com/proxy-rs/quinn-congestions.git#2bdc356f57a7fc3ae1a49ab963a221f42d61012f"
 dependencies = [
  "quinn 0.12.0",
  "quinn-proto 0.12.0",
- "rand 0.9.2",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -2199,7 +2196,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2214,7 +2211,7 @@ dependencies = [
 [[package]]
 name = "quinn-proto"
 version = "0.12.0"
-source = "git+https://github.com/Tipuch/quinn.git?branch=bbrv3#3896e5b27db244e40f9d1ea5c46f2d4c46f5c8aa"
+source = "git+https://github.com/Tipuch/quinn.git?branch=bbrv3#ce60e5b5c115db2a6053f4e0ca7fc52103cb76b9"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -2222,7 +2219,7 @@ dependencies = [
  "getrandom 0.3.4",
  "lru-slab",
  "qlog",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_pcg",
  "ring",
  "rustc-hash",
@@ -2253,7 +2250,7 @@ dependencies = [
 [[package]]
 name = "quinn-udp"
 version = "0.6.1"
-source = "git+https://github.com/Tipuch/quinn.git?branch=bbrv3#3896e5b27db244e40f9d1ea5c46f2d4c46f5c8aa"
+source = "git+https://github.com/Tipuch/quinn.git?branch=bbrv3#ce60e5b5c115db2a6053f4e0ca7fc52103cb76b9"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -2285,9 +2282,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -2295,13 +2292,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2325,9 +2322,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_pcg"
@@ -2450,7 +2447,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2469,9 +2466,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -2506,9 +2503,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -2544,7 +2541,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tower-service",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
  "x509-parser 0.16.0",
 ]
 
@@ -2571,9 +2568,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -2581,9 +2578,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
@@ -2608,9 +2605,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2694,9 +2691,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2785,9 +2782,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
 dependencies = [
  "serde_core",
  "serde_with_macros",
@@ -2795,9 +2792,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2874,7 +2871,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2903,6 +2900,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2919,9 +2932,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "socket2"
@@ -3138,9 +3148,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3163,9 +3173,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -3180,9 +3190,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3249,9 +3259,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "994b95d9e7bae62b34bab0e2a4510b801fa466066a6a8b2b57361fa1eba068ee"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -3259,7 +3269,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.0",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -3296,11 +3306,11 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ca317ebc49f06bd748bfba29533eac9485569dc9bf80b849024b025e814fb9"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.0",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -3487,7 +3497,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-util",
- "toml 1.1.1+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "tuic-core",
@@ -3502,6 +3512,7 @@ dependencies = [
  "eyre",
  "futures-util",
  "parking_lot",
+ "peekable",
  "quinn 0.12.0",
  "rcgen 0.14.7",
  "register-count",
@@ -3549,7 +3560,7 @@ dependencies = [
  "pest_derive",
  "quinn 0.12.0",
  "quinn-congestions",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rcgen 0.14.7",
  "regex",
  "register-count",
@@ -3560,6 +3571,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "smallvec",
  "socket2 0.6.3",
  "tempfile",
  "thiserror 2.0.18",
@@ -3569,7 +3581,7 @@ dependencies = [
  "tokio-stream",
  "tokio-test",
  "tokio-util",
- "toml 1.1.1+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "tuic-core",
@@ -3600,9 +3612,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -3627,9 +3639,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da36089a805484bcccfffe0739803392c8298778a2d2f09febf76fac5ad9025b"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-xid"
@@ -3681,9 +3693,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -3730,11 +3742,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -3743,14 +3755,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3761,23 +3773,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3785,9 +3793,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3798,9 +3806,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -3854,9 +3862,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3874,9 +3882,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3887,14 +3895,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3969,15 +3977,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -4001,21 +4000,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -4053,12 +4037,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4071,12 +4049,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4086,12 +4058,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4119,12 +4085,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4134,12 +4094,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4155,12 +4109,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4170,12 +4118,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4200,9 +4142,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "wit-bindgen"
@@ -4212,6 +4154,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -4294,9 +4242,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x509-parser"
@@ -4351,9 +4299,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -4362,9 +4310,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4374,18 +4322,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4394,18 +4342,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4421,9 +4369,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4432,9 +4380,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4443,9 +4391,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,6 +1189,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "h3"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10872b55cfb02a821b69dc7cf8dc6a71d6af25eb9a79662bec4a9d016056b3be"
+dependencies = [
+ "bytes",
+ "fastrand",
+ "futures-util",
+ "http",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1947,6 +1961,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "peekable"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43fd2346a004ab7b18c468ad8f9554970a14872a701450155248ff5af73af53b"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2396,6 +2420,8 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -2415,12 +2441,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.6",
 ]
@@ -3505,6 +3533,9 @@ dependencies = [
  "eyre",
  "figment",
  "figment-json5",
+ "futures",
+ "futures-util",
+ "h3",
  "http",
  "humantime",
  "humantime-serde",
@@ -3513,6 +3544,7 @@ dependencies = [
  "json5 1.3.1",
  "moka",
  "num_cpus",
+ "peekable",
  "pest",
  "pest_derive",
  "quinn 0.12.0",
@@ -3793,6 +3825,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/LLM.md
+++ b/LLM.md
@@ -15,8 +15,10 @@ Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
 | Component | Description |
 |-----------|-------------|
 | `AGENT_NAME` | The name of the AI tool or framework used (e.g., Claude, OpenClaw, Copilot) |
-| `MODEL_VERSION` | The specific model version (e.g., claude-3-opus, gemini-2.5-pro, k2p5) |
+| `MODEL_VERSION` | The specific model version without provider prefix (e.g., `claude-3-opus`, `gpt-4o`, `deepseek-v4-flash` — not `deepseek/deepseek-v4-flash`) |
 | `[TOOL1] [TOOL2]` | Optional: Additional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy) |
+
+> **Important:** Do **not** include the provider prefix in `MODEL_VERSION`. For example, write `deepseek-v4-flash`, not `deepseek/deepseek-v4-flash`. The provider/API routing detail is irrelevant to readers; only the model identity matters.
 
 ### Notes
 

--- a/LLM.md
+++ b/LLM.md
@@ -1,0 +1,82 @@
+# AI-Assisted Contribution Guidelines
+
+This document outlines the requirements for contributions that involve AI assistance in this project.
+
+## Assisted-by Tag Requirement
+
+When AI tools are used during development, the source must be clearly documented so everyone can understand the extent of AI involvement in each submission. All code contributions involving AI assistance must include an `Assisted-by` tag using the following format:
+
+```
+Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
+```
+
+### Format Specification
+
+| Component | Description |
+|-----------|-------------|
+| `AGENT_NAME` | The name of the AI tool or framework used (e.g., Claude, OpenClaw, Copilot) |
+| `MODEL_VERSION` | The specific model version (e.g., claude-3-opus, gemini-2.5-pro, k2p5) |
+| `[TOOL1] [TOOL2]` | Optional: Additional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy) |
+
+### Notes
+
+- **Do not include** common everyday tools like git, gcc, make, or text editors
+- Only list specialized analysis or transformation tools that significantly contributed to the code
+- Multiple `Assisted-by` tags may be used if different AI tools were used for different parts of the contribution
+
+### Examples
+
+**Using Claude with coccinelle and sparse:**
+```
+Assisted-by: Claude:claude-3-opus coccinelle sparse
+```
+
+**Using OpenClaw with no additional tools:**
+```
+Assisted-by: OpenClaw:k2p5
+```
+
+**Using GitHub Copilot:**
+```
+Assisted-by: Copilot:gpt-4o
+```
+
+**Multiple AI tools used:**
+```
+Assisted-by: Claude:claude-3-opus clang-tidy
+Assisted-by: OpenClaw:gemini-3.1-pro-preview
+```
+
+## Where to Include
+
+Add the `Assisted-by` tag(s) at the end of your commit message, after the sign-off line (if present):
+
+```
+Fix memory leak in request handler
+
+This patch fixes a use-after-free bug in the async request handler
+that could occur during rapid create/destroy cycles.
+
+Signed-off-by: John Doe <john@example.com>
+Assisted-by: Claude:claude-3-opus coccinelle sparse
+```
+
+## Why This Matters
+
+1. **Transparency**: Maintainers and reviewers should know when AI has assisted in code creation
+2. **Attribution**: Proper credit for AI contributions helps track the evolution of development practices
+3. **Quality Assurance**: Understanding AI involvement helps set appropriate review standards
+4. **Audit Trail**: Creates a clear record for future reference and analysis
+
+## Scope
+
+This requirement applies to:
+- Code changes (any language)
+- Configuration files
+- Build scripts
+- Documentation (if substantially AI-generated)
+
+This requirement does **not** apply to:
+- Minor typo fixes
+- Pure formatting changes
+- Changes made entirely without AI assistance

--- a/tuic-core/Cargo.toml
+++ b/tuic-core/Cargo.toml
@@ -21,6 +21,7 @@ aws-lc-rs = ["rustls/aws-lc-rs", "tokio-rustls/aws-lc-rs"]
 [dependencies]
 # From tuic
 bytes = { version = "1", default-features = false, features = ["std"] }
+peekable = { version = "0.6", default-features = false, features = ["tokio", "smallvec"] }
 futures-util = { version = "0.3", default-features = false, features = ["io", "std"], optional = true }
 parking_lot = { version = "0.12", default-features = false, optional = true }
 register-count = { version = "0.1", default-features = false, features = ["std"], optional = true }

--- a/tuic-core/src/quinn.rs
+++ b/tuic-core/src/quinn.rs
@@ -9,6 +9,7 @@ use std::{
 pub use ::quinn;
 use ::quinn::{Connection as QuinnConnection, ConnectionError, RecvStream, SendDatagramError, SendStream, VarInt};
 use bytes::{BufMut, Bytes, BytesMut};
+use futures_util::AsyncRead as FuturesAsyncRead;
 use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, ReadBuf};
 use tracing::warn;
@@ -275,6 +276,35 @@ impl Connection<side::Server> {
 		}
 	}
 
+	/// Try to parse a `quinn::RecvStream` as a TUIC command with prefetched
+	/// prefix bytes.
+	pub async fn accept_uni_stream_prefixed(&self, recv: RecvStream, prefix: Bytes) -> Result<Task, Error> {
+		let mut prefixed = PrefixedRecvStream::new(recv, prefix);
+
+		let header = match Header::async_unmarshal(&mut prefixed).await {
+			Ok(header) => header,
+			Err(err) => return Err(Error::UnmarshalUniStream(err, prefixed.into_inner())),
+		};
+		let recv = prefixed.into_inner();
+
+		match header {
+			Header::Authenticate(auth) => {
+				let model = self.model.recv_authenticate(auth);
+				Ok(Task::Authenticate(Authenticate::new(model, self.keying_material_exporter())))
+			}
+			Header::Connect(_) => Err(Error::BadCommandUniStream("connect", recv)),
+			Header::Packet(pkt) => {
+				let model = self.model.recv_packet_unrestricted(pkt);
+				Ok(Task::Packet(Packet::new(model, PacketSource::Quic(recv))))
+			}
+			Header::Dissociate(dissoc) => {
+				let model = self.model.recv_dissociate(dissoc);
+				Ok(Task::Dissociate(model.assoc_id()))
+			}
+			Header::Heartbeat(_) => Err(Error::BadCommandUniStream("heartbeat", recv)),
+		}
+	}
+
 	/// Try to parse a pair of `quinn::SendStream` and `quinn::RecvStream` as a
 	/// TUIC command.
 	///
@@ -285,6 +315,28 @@ impl Connection<side::Server> {
 			Ok(header) => header,
 			Err(err) => return Err(Error::UnmarshalBiStream(err, send, recv)),
 		};
+
+		match header {
+			Header::Authenticate(_) => Err(Error::BadCommandBiStream("authenticate", send, recv)),
+			Header::Connect(conn) => {
+				let model = self.model.recv_connect(conn);
+				Ok(Task::Connect(Connect::new(Side::Server(model), send, recv)))
+			}
+			Header::Packet(_) => Err(Error::BadCommandBiStream("packet", send, recv)),
+			Header::Dissociate(_) => Err(Error::BadCommandBiStream("dissociate", send, recv)),
+			Header::Heartbeat(_) => Err(Error::BadCommandBiStream("heartbeat", send, recv)),
+		}
+	}
+
+	/// Try to parse a pair of `quinn::SendStream` and `quinn::RecvStream` as a
+	/// TUIC command with prefetched prefix bytes from `recv`.
+	pub async fn accept_bi_stream_prefixed(&self, send: SendStream, recv: RecvStream, prefix: Bytes) -> Result<Task, Error> {
+		let mut prefixed = PrefixedRecvStream::new(recv, prefix);
+		let header = match Header::async_unmarshal(&mut prefixed).await {
+			Ok(header) => header,
+			Err(err) => return Err(Error::UnmarshalBiStream(err, send, prefixed.into_inner())),
+		};
+		let recv = prefixed.into_inner();
 
 		match header {
 			Header::Authenticate(_) => Err(Error::BadCommandBiStream("authenticate", send, recv)),
@@ -325,6 +377,45 @@ impl Connection<side::Server> {
 				Ok(Task::Heartbeat)
 			}
 		}
+	}
+}
+
+struct PrefixedRecvStream {
+	recv:       RecvStream,
+	prefix:     Bytes,
+	prefix_pos: usize,
+}
+
+impl PrefixedRecvStream {
+	fn new(recv: RecvStream, prefix: Bytes) -> Self {
+		Self {
+			recv,
+			prefix,
+			prefix_pos: 0,
+		}
+	}
+
+	fn into_inner(self) -> RecvStream {
+		self.recv
+	}
+}
+
+impl FuturesAsyncRead for PrefixedRecvStream {
+	fn poll_read(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<Result<usize, IoError>> {
+		if buf.is_empty() {
+			return Poll::Ready(Ok(0));
+		}
+
+		let prefix_len = self.prefix.len();
+		if self.prefix_pos < prefix_len {
+			let remaining = &self.prefix[self.prefix_pos..];
+			let copy_len = remaining.len().min(buf.len());
+			buf[..copy_len].copy_from_slice(&remaining[..copy_len]);
+			self.prefix_pos += copy_len;
+			return Poll::Ready(Ok(copy_len));
+		}
+
+		FuturesAsyncRead::poll_read(Pin::new(&mut self.recv), cx, buf)
 	}
 }
 

--- a/tuic-core/src/quinn.rs
+++ b/tuic-core/src/quinn.rs
@@ -9,7 +9,6 @@ use std::{
 pub use ::quinn;
 use ::quinn::{Connection as QuinnConnection, ConnectionError, RecvStream, SendDatagramError, SendStream, VarInt};
 use bytes::{BufMut, Bytes, BytesMut};
-use futures_util::AsyncRead as FuturesAsyncRead;
 use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, ReadBuf};
 use tracing::warn;
@@ -39,12 +38,46 @@ pub mod side {
 	}
 }
 
+/// Trait abstracting QUIC send stream operations.
+pub trait StreamTx: tokio::io::AsyncWrite + futures_util::AsyncWrite + Unpin + Send {
+	/// Notify the peer that no more data will be written to this stream.
+	fn finish(&mut self) -> Result<(), ::quinn::ClosedStream>;
+	/// Wait for the stream to be stopped or read to completion by the peer.
+	fn stopped(&mut self) -> impl std::future::Future<Output = Result<Option<VarInt>, ::quinn::StoppedError>> + Send;
+	/// Close the send stream immediately with the given error code.
+	fn reset(&mut self, error_code: VarInt) -> Result<(), ::quinn::ClosedStream>;
+}
+
+/// Trait abstracting QUIC receive stream operations.
+pub trait StreamRx: tokio::io::AsyncRead + Unpin + Send {
+	/// Stop accepting data and notify the peer to stop transmitting.
+	fn stop(&mut self, error_code: VarInt) -> Result<(), ::quinn::ClosedStream>;
+}
+
+impl StreamTx for ::quinn::SendStream {
+	fn finish(&mut self) -> Result<(), ::quinn::ClosedStream> {
+		SendStream::finish(self)
+	}
+
+	fn stopped(&mut self) -> impl std::future::Future<Output = Result<Option<VarInt>, ::quinn::StoppedError>> + Send {
+		SendStream::stopped(self)
+	}
+
+	fn reset(&mut self, error_code: VarInt) -> Result<(), ::quinn::ClosedStream> {
+		SendStream::reset(self, error_code)
+	}
+}
+
+impl StreamRx for ::quinn::RecvStream {
+	fn stop(&mut self, error_code: VarInt) -> Result<(), ::quinn::ClosedStream> {
+		RecvStream::stop(self, error_code)
+	}
+}
+
 /// The TUIC Connection.
 ///
 /// This struct takes a clone of `quinn::Connection` for performing TUIC
 /// operations.
-///
-/// See more details about the TUIC protocol at [SPEC.md](https://github.com/EAimTY/tuic/blob/dev/tuic/SPEC.md)
 #[derive(Clone)]
 pub struct Connection<Side> {
 	conn:    QuinnConnection,
@@ -276,35 +309,6 @@ impl Connection<side::Server> {
 		}
 	}
 
-	/// Try to parse a `quinn::RecvStream` as a TUIC command with prefetched
-	/// prefix bytes.
-	pub async fn accept_uni_stream_prefixed(&self, recv: RecvStream, prefix: Bytes) -> Result<Task, Error> {
-		let mut prefixed = PrefixedRecvStream::new(recv, prefix);
-
-		let header = match Header::async_unmarshal(&mut prefixed).await {
-			Ok(header) => header,
-			Err(err) => return Err(Error::UnmarshalUniStream(err, prefixed.into_inner())),
-		};
-		let recv = prefixed.into_inner();
-
-		match header {
-			Header::Authenticate(auth) => {
-				let model = self.model.recv_authenticate(auth);
-				Ok(Task::Authenticate(Authenticate::new(model, self.keying_material_exporter())))
-			}
-			Header::Connect(_) => Err(Error::BadCommandUniStream("connect", recv)),
-			Header::Packet(pkt) => {
-				let model = self.model.recv_packet_unrestricted(pkt);
-				Ok(Task::Packet(Packet::new(model, PacketSource::Quic(recv))))
-			}
-			Header::Dissociate(dissoc) => {
-				let model = self.model.recv_dissociate(dissoc);
-				Ok(Task::Dissociate(model.assoc_id()))
-			}
-			Header::Heartbeat(_) => Err(Error::BadCommandUniStream("heartbeat", recv)),
-		}
-	}
-
 	/// Try to parse a pair of `quinn::SendStream` and `quinn::RecvStream` as a
 	/// TUIC command.
 	///
@@ -315,28 +319,6 @@ impl Connection<side::Server> {
 			Ok(header) => header,
 			Err(err) => return Err(Error::UnmarshalBiStream(err, send, recv)),
 		};
-
-		match header {
-			Header::Authenticate(_) => Err(Error::BadCommandBiStream("authenticate", send, recv)),
-			Header::Connect(conn) => {
-				let model = self.model.recv_connect(conn);
-				Ok(Task::Connect(Connect::new(Side::Server(model), send, recv)))
-			}
-			Header::Packet(_) => Err(Error::BadCommandBiStream("packet", send, recv)),
-			Header::Dissociate(_) => Err(Error::BadCommandBiStream("dissociate", send, recv)),
-			Header::Heartbeat(_) => Err(Error::BadCommandBiStream("heartbeat", send, recv)),
-		}
-	}
-
-	/// Try to parse a pair of `quinn::SendStream` and `quinn::RecvStream` as a
-	/// TUIC command with prefetched prefix bytes from `recv`.
-	pub async fn accept_bi_stream_prefixed(&self, send: SendStream, recv: RecvStream, prefix: Bytes) -> Result<Task, Error> {
-		let mut prefixed = PrefixedRecvStream::new(recv, prefix);
-		let header = match Header::async_unmarshal(&mut prefixed).await {
-			Ok(header) => header,
-			Err(err) => return Err(Error::UnmarshalBiStream(err, send, prefixed.into_inner())),
-		};
-		let recv = prefixed.into_inner();
 
 		match header {
 			Header::Authenticate(_) => Err(Error::BadCommandBiStream("authenticate", send, recv)),
@@ -377,45 +359,6 @@ impl Connection<side::Server> {
 				Ok(Task::Heartbeat)
 			}
 		}
-	}
-}
-
-struct PrefixedRecvStream {
-	recv:       RecvStream,
-	prefix:     Bytes,
-	prefix_pos: usize,
-}
-
-impl PrefixedRecvStream {
-	fn new(recv: RecvStream, prefix: Bytes) -> Self {
-		Self {
-			recv,
-			prefix,
-			prefix_pos: 0,
-		}
-	}
-
-	fn into_inner(self) -> RecvStream {
-		self.recv
-	}
-}
-
-impl FuturesAsyncRead for PrefixedRecvStream {
-	fn poll_read(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<Result<usize, IoError>> {
-		if buf.is_empty() {
-			return Poll::Ready(Ok(0));
-		}
-
-		let prefix_len = self.prefix.len();
-		if self.prefix_pos < prefix_len {
-			let remaining = &self.prefix[self.prefix_pos..];
-			let copy_len = remaining.len().min(buf.len());
-			buf[..copy_len].copy_from_slice(&remaining[..copy_len]);
-			self.prefix_pos += copy_len;
-			return Poll::Ready(Ok(copy_len));
-		}
-
-		FuturesAsyncRead::poll_read(Pin::new(&mut self.recv), cx, buf)
 	}
 }
 

--- a/tuic-core/src/quinn.rs
+++ b/tuic-core/src/quinn.rs
@@ -9,6 +9,7 @@ use std::{
 pub use ::quinn;
 use ::quinn::{Connection as QuinnConnection, ConnectionError, RecvStream, SendDatagramError, SendStream, VarInt};
 use bytes::{BufMut, Bytes, BytesMut};
+use peekable::{buffer::Buffer, tokio::AsyncPeekable};
 use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, ReadBuf};
 use tracing::warn;
@@ -19,8 +20,7 @@ use crate::{
 	Address, Header, UnmarshalError,
 	model::{
 		AssembleError, Authenticate as AuthenticateModel, Connect as ConnectModel, Connection as ConnectionModel,
-		KeyingMaterialExporter as KeyingMaterialExporterImpl, Packet as PacketModel,
-		side::{Rx, Tx},
+		KeyingMaterialExporter as KeyingMaterialExporterImpl, Packet as PacketModel, side as model_side,
 	},
 };
 
@@ -71,6 +71,13 @@ impl StreamTx for ::quinn::SendStream {
 impl StreamRx for ::quinn::RecvStream {
 	fn stop(&mut self, error_code: VarInt) -> Result<(), ::quinn::ClosedStream> {
 		RecvStream::stop(self, error_code)
+	}
+}
+
+impl<R: StreamRx, B: Buffer + Send> StreamRx for AsyncPeekable<R, B> {
+	fn stop(&mut self, error_code: VarInt) -> Result<(), ::quinn::ClosedStream> {
+		let (_, inner) = self.get_mut();
+		inner.stop(error_code)
 	}
 }
 
@@ -187,19 +194,19 @@ impl Connection<side::Client> {
 		Ok(())
 	}
 
-	/// Try to parse a `quinn::RecvStream` as a TUIC command.
+	/// Try to parse a unidirectional stream as a TUIC command.
 	///
-	/// The `quinn::RecvStream` should be accepted by
-	/// `quinn::Connection::accept_uni()` from the same `quinn::Connection`.
-	pub async fn accept_uni_stream(&self, mut recv: RecvStream) -> Result<Task, Error> {
+	/// The stream should be accepted by `quinn::Connection::accept_uni()`
+	/// from the same `QuinnConnection`.
+	pub async fn accept_uni_stream<R: StreamRx>(&self, mut recv: R) -> Result<Task<SendStream, R>, Error> {
 		let header = match Header::async_unmarshal(&mut recv).await {
 			Ok(header) => header,
-			Err(err) => return Err(Error::UnmarshalUniStream(err, recv)),
+			Err(err) => return Err(Error::UnmarshalUniStream(err)),
 		};
 
 		match header {
-			Header::Authenticate(_) => Err(Error::BadCommandUniStream("authenticate", recv)),
-			Header::Connect(_) => Err(Error::BadCommandUniStream("connect", recv)),
+			Header::Authenticate(_) => Err(Error::BadCommandUniStream("authenticate")),
+			Header::Connect(_) => Err(Error::BadCommandUniStream("connect")),
 			Header::Packet(pkt) => {
 				let assoc_id = pkt.assoc_id();
 				let pkt_id = pkt.pkt_id();
@@ -209,28 +216,27 @@ impl Connection<side::Client> {
 						Ok(Task::Packet(Packet::new(pkt, PacketSource::Quic(recv))))
 					})
 			}
-			Header::Dissociate(_) => Err(Error::BadCommandUniStream("dissociate", recv)),
-			Header::Heartbeat(_) => Err(Error::BadCommandUniStream("heartbeat", recv)),
+			Header::Dissociate(_) => Err(Error::BadCommandUniStream("dissociate")),
+			Header::Heartbeat(_) => Err(Error::BadCommandUniStream("heartbeat")),
 		}
 	}
 
-	/// Try to parse a pair of `quinn::SendStream` and `quinn::RecvStream` as a
-	/// TUIC command.
+	/// Try to parse a pair of send/receive streams as a TUIC command.
 	///
-	/// The pair of stream should be accepted by
-	/// `quinn::Connection::accept_bi()` from the same `quinn::Connection`.
-	pub async fn accept_bi_stream(&self, send: SendStream, mut recv: RecvStream) -> Result<Task, Error> {
+	/// The pair of streams should be accepted by
+	/// `quinn::Connection::accept_bi()` from the same `QuinnConnection`.
+	pub async fn accept_bi_stream<S: StreamTx, R: StreamRx>(&self, _send: S, mut recv: R) -> Result<Task<S, R>, Error> {
 		let header = match Header::async_unmarshal(&mut recv).await {
 			Ok(header) => header,
-			Err(err) => return Err(Error::UnmarshalBiStream(err, send, recv)),
+			Err(err) => return Err(Error::UnmarshalBiStream(err)),
 		};
 
 		match header {
-			Header::Authenticate(_) => Err(Error::BadCommandBiStream("authenticate", send, recv)),
-			Header::Connect(_) => Err(Error::BadCommandBiStream("connect", send, recv)),
-			Header::Packet(_) => Err(Error::BadCommandBiStream("packet", send, recv)),
-			Header::Dissociate(_) => Err(Error::BadCommandBiStream("dissociate", send, recv)),
-			Header::Heartbeat(_) => Err(Error::BadCommandBiStream("heartbeat", send, recv)),
+			Header::Authenticate(_) => Err(Error::BadCommandBiStream("authenticate")),
+			Header::Connect(_) => Err(Error::BadCommandBiStream("connect")),
+			Header::Packet(_) => Err(Error::BadCommandBiStream("packet")),
+			Header::Dissociate(_) => Err(Error::BadCommandBiStream("dissociate")),
+			Header::Heartbeat(_) => Err(Error::BadCommandBiStream("heartbeat")),
 		}
 	}
 
@@ -281,14 +287,14 @@ impl Connection<side::Server> {
 		}
 	}
 
-	/// Try to parse a `quinn::RecvStream` as a TUIC command.
+	/// Try to parse a unidirectional stream as a TUIC command.
 	///
-	/// The `quinn::RecvStream` should be accepted by
-	/// `quinn::Connection::accept_uni()` from the same `quinn::Connection`.
-	pub async fn accept_uni_stream(&self, mut recv: RecvStream) -> Result<Task, Error> {
+	/// The stream should be accepted by `quinn::Connection::accept_uni()`
+	/// from the same `QuinnConnection`.
+	pub async fn accept_uni_stream<R: StreamRx>(&self, mut recv: R) -> Result<Task<SendStream, R>, Error> {
 		let header = match Header::async_unmarshal(&mut recv).await {
 			Ok(header) => header,
-			Err(err) => return Err(Error::UnmarshalUniStream(err, recv)),
+			Err(err) => return Err(Error::UnmarshalUniStream(err)),
 		};
 
 		match header {
@@ -296,7 +302,7 @@ impl Connection<side::Server> {
 				let model = self.model.recv_authenticate(auth);
 				Ok(Task::Authenticate(Authenticate::new(model, self.keying_material_exporter())))
 			}
-			Header::Connect(_) => Err(Error::BadCommandUniStream("connect", recv)),
+			Header::Connect(_) => Err(Error::BadCommandUniStream("connect")),
 			Header::Packet(pkt) => {
 				let model = self.model.recv_packet_unrestricted(pkt);
 				Ok(Task::Packet(Packet::new(model, PacketSource::Quic(recv))))
@@ -305,30 +311,29 @@ impl Connection<side::Server> {
 				let model = self.model.recv_dissociate(dissoc);
 				Ok(Task::Dissociate(model.assoc_id()))
 			}
-			Header::Heartbeat(_) => Err(Error::BadCommandUniStream("heartbeat", recv)),
+			Header::Heartbeat(_) => Err(Error::BadCommandUniStream("heartbeat")),
 		}
 	}
 
-	/// Try to parse a pair of `quinn::SendStream` and `quinn::RecvStream` as a
-	/// TUIC command.
+	/// Try to parse a pair of send/receive streams as a TUIC command.
 	///
-	/// The pair of stream should be accepted by
-	/// `quinn::Connection::accept_bi()` from the same `quinn::Connection`.
-	pub async fn accept_bi_stream(&self, send: SendStream, mut recv: RecvStream) -> Result<Task, Error> {
+	/// The pair of streams should be accepted by
+	/// `quinn::Connection::accept_bi()` from the same `QuinnConnection`.
+	pub async fn accept_bi_stream<S: StreamTx, R: StreamRx>(&self, send: S, mut recv: R) -> Result<Task<S, R>, Error> {
 		let header = match Header::async_unmarshal(&mut recv).await {
 			Ok(header) => header,
-			Err(err) => return Err(Error::UnmarshalBiStream(err, send, recv)),
+			Err(err) => return Err(Error::UnmarshalBiStream(err)),
 		};
 
 		match header {
-			Header::Authenticate(_) => Err(Error::BadCommandBiStream("authenticate", send, recv)),
+			Header::Authenticate(_) => Err(Error::BadCommandBiStream("authenticate")),
 			Header::Connect(conn) => {
 				let model = self.model.recv_connect(conn);
 				Ok(Task::Connect(Connect::new(Side::Server(model), send, recv)))
 			}
-			Header::Packet(_) => Err(Error::BadCommandBiStream("packet", send, recv)),
-			Header::Dissociate(_) => Err(Error::BadCommandBiStream("dissociate", send, recv)),
-			Header::Heartbeat(_) => Err(Error::BadCommandBiStream("heartbeat", send, recv)),
+			Header::Packet(_) => Err(Error::BadCommandBiStream("packet")),
+			Header::Dissociate(_) => Err(Error::BadCommandBiStream("dissociate")),
+			Header::Heartbeat(_) => Err(Error::BadCommandBiStream("heartbeat")),
 		}
 	}
 
@@ -374,12 +379,12 @@ impl<Side> Debug for Connection<Side> {
 /// A received `Authenticate` command.
 #[derive(Debug)]
 pub struct Authenticate {
-	model:    AuthenticateModel<Rx>,
+	model:    AuthenticateModel<model_side::Rx>,
 	exporter: KeyingMaterialExporter,
 }
 
 impl Authenticate {
-	fn new(model: AuthenticateModel<Rx>, exporter: KeyingMaterialExporter) -> Self {
+	fn new(model: AuthenticateModel<model_side::Rx>, exporter: KeyingMaterialExporter) -> Self {
 		Self { model, exporter }
 	}
 
@@ -400,14 +405,17 @@ impl Authenticate {
 }
 
 /// A received `Connect` command.
-pub struct Connect {
-	model:    Side<ConnectModel<Tx>, ConnectModel<Rx>>,
-	pub send: SendStream,
-	pub recv: RecvStream,
+///
+/// Generic over the QUIC send/receive stream types, allowing use with
+/// different QUIC implementations that implement `StreamTx`/`StreamRx`.
+pub struct Connect<S: StreamTx = SendStream, R: StreamRx = RecvStream> {
+	model:    Side<ConnectModel<model_side::Tx>, ConnectModel<model_side::Rx>>,
+	pub send: S,
+	pub recv: R,
 }
 
-impl Connect {
-	fn new(model: Side<ConnectModel<Tx>, ConnectModel<Rx>>, send: SendStream, recv: RecvStream) -> Self {
+impl<S: StreamTx, R: StreamRx> Connect<S, R> {
+	fn new(model: Side<ConnectModel<model_side::Tx>, ConnectModel<model_side::Rx>>, send: S, recv: R) -> Self {
 		Self { model, send, recv }
 	}
 
@@ -442,13 +450,13 @@ impl Connect {
 	}
 }
 
-impl AsyncRead for Connect {
+impl<S: StreamTx, R: StreamRx> AsyncRead for Connect<S, R> {
 	fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut ReadBuf<'_>) -> Poll<std::io::Result<()>> {
 		AsyncRead::poll_read(Pin::new(&mut self.get_mut().recv), cx, buf)
 	}
 }
 
-impl AsyncWrite for Connect {
+impl<S: StreamTx, R: StreamRx> AsyncWrite for Connect<S, R> {
 	fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, IoError>> {
 		AsyncWrite::poll_write(Pin::new(&mut self.get_mut().send), cx, buf)
 	}
@@ -462,7 +470,7 @@ impl AsyncWrite for Connect {
 	}
 }
 
-impl Debug for Connect {
+impl<S: StreamTx + Debug, R: StreamRx + Debug> Debug for Connect<S, R> {
 	fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
 		let model = match &self.model {
 			Side::Client(model) => model as &dyn Debug,
@@ -477,21 +485,21 @@ impl Debug for Connect {
 	}
 }
 
-/// A received `Packet` command.
+/// Source of a received `Packet` command.
 #[derive(Debug)]
-pub struct Packet {
-	model: PacketModel<Rx, Bytes>,
-	src:   PacketSource,
-}
-
-#[derive(Debug)]
-enum PacketSource {
-	Quic(RecvStream),
+pub enum PacketSource<R: StreamRx = RecvStream> {
+	Quic(R),
 	Native(Bytes),
 }
 
-impl Packet {
-	fn new(model: PacketModel<Rx, Bytes>, src: PacketSource) -> Self {
+/// A received `Packet` command.
+pub struct Packet<R: StreamRx = RecvStream> {
+	model: PacketModel<model_side::Rx, Bytes>,
+	src:   PacketSource<R>,
+}
+
+impl<R: StreamRx> Packet<R> {
+	fn new(model: PacketModel<model_side::Rx, Bytes>, src: PacketSource<R>) -> Self {
 		Self { src, model }
 	}
 
@@ -547,13 +555,22 @@ impl Packet {
 	}
 }
 
+impl<R: StreamRx + Debug> Debug for Packet<R> {
+	fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+		f.debug_struct("Packet")
+			.field("model", &self.model)
+			.field("src", &self.src)
+			.finish()
+	}
+}
+
 /// Type of tasks that can be received.
 #[non_exhaustive]
 #[derive(Debug)]
-pub enum Task {
+pub enum Task<S: StreamTx = SendStream, R: StreamRx = RecvStream> {
 	Authenticate(Authenticate),
-	Connect(Connect),
-	Packet(Packet),
+	Connect(Connect<S, R>),
+	Packet(Packet<R>),
 	Dissociate(u16),
 	Heartbeat,
 }
@@ -588,15 +605,15 @@ pub enum Error {
 	#[error(transparent)]
 	Assemble(#[from] AssembleError),
 	#[error("error unmarshalling uni_stream: {0}")]
-	UnmarshalUniStream(UnmarshalError, RecvStream),
+	UnmarshalUniStream(UnmarshalError),
 	#[error("error unmarshalling bi_stream: {0}")]
-	UnmarshalBiStream(UnmarshalError, SendStream, RecvStream),
+	UnmarshalBiStream(UnmarshalError),
 	#[error("error unmarshalling datagram: {0}")]
 	UnmarshalDatagram(UnmarshalError, Bytes),
 	#[error("bad command `{0}` from uni_stream")]
-	BadCommandUniStream(&'static str, RecvStream),
+	BadCommandUniStream(&'static str),
 	#[error("bad command `{0}` from bi_stream")]
-	BadCommandBiStream(&'static str, SendStream, RecvStream),
+	BadCommandBiStream(&'static str),
 	#[error("bad command `{0}` from datagram")]
 	BadCommandDatagram(&'static str, Bytes),
 	#[error(transparent)]

--- a/tuic-core/src/unmarshal.rs
+++ b/tuic-core/src/unmarshal.rs
@@ -4,7 +4,7 @@ use std::{
 	string::FromUtf8Error,
 };
 
-use futures_util::{AsyncRead, AsyncReadExt};
+use tokio::io::{AsyncRead, AsyncReadExt};
 use thiserror::Error;
 use uuid::{Error as UuidError, Uuid};
 

--- a/tuic-core/src/unmarshal.rs
+++ b/tuic-core/src/unmarshal.rs
@@ -4,8 +4,8 @@ use std::{
 	string::FromUtf8Error,
 };
 
-use tokio::io::{AsyncRead, AsyncReadExt};
 use thiserror::Error;
+use tokio::io::{AsyncRead, AsyncReadExt};
 use uuid::{Error as UuidError, Uuid};
 
 use crate::{Address, Authenticate, Connect, Dissociate, Header, Heartbeat, Packet, VERSION};

--- a/tuic-server/Cargo.toml
+++ b/tuic-server/Cargo.toml
@@ -18,6 +18,7 @@ aws-lc-rs = ["tuic-core/aws-lc-rs", "dep:aws-lc-rs", "rustls/aws-lc-rs", "rcgen/
 jemallocator = ["tikv-jemallocator"]
 
 [dependencies]
+h3 = "0.0.8"
 
 num_cpus = "1"
 toml = "1.1"
@@ -80,10 +81,10 @@ eyre = { version = "0.6" }
 axum = { version = "0.8", features = ["json", "tokio"] }
 axum-extra = { version = "0.12", features = ["typed-header"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "http2", "stream"] }
-h3 = "0.0.8"
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 futures = "0.3"
-peekable = { version = "0.6.1", default-features = false, features = ["future"] }
+peekable = { version = "0.6.1", default-features = false, features = ["tokio"] }
+smallvec = { version = "1", default-features = false }
 
 tikv-jemallocator = { version = "0.6", optional = true }
 rand = "0.10"

--- a/tuic-server/Cargo.toml
+++ b/tuic-server/Cargo.toml
@@ -79,12 +79,16 @@ eyre = { version = "0.6" }
 # Web
 axum = { version = "0.8", features = ["json", "tokio"] }
 axum-extra = { version = "0.12", features = ["typed-header"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "http2", "stream"] }
+h3 = "0.0.8"
+futures-util = { version = "0.3", default-features = false, features = ["std"] }
+futures = "0.3"
+peekable = { version = "0.6.1", default-features = false, features = ["future"] }
 
 tikv-jemallocator = { version = "0.6", optional = true }
 rand = "0.10"
 
 [dev-dependencies]
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"]}
 tempfile = "3"
 tokio = { version = "1", features = ["full", "test-util"] }
 x509-parser = "0.18"

--- a/tuic-server/README.md
+++ b/tuic-server/README.md
@@ -198,6 +198,22 @@ auto_ssl = false
 # (Optional) email for ACME account creation, if left empty, will use 'admin@<hostname>' or 'admin@<random_string>.com'
 acme_email = ""
 
+[camouflage]
+# Enable HTTP/3 camouflage mode for non-TUIC ALPN `h3*` traffic
+enabled = false
+# Reverse proxy target for camouflage requests
+# (usually an HTTP/2 or HTTP/1.1 web server endpoint)
+reverse_proxy_url = "https://127.0.0.1:443"
+# Optional backend server name. When set, it is used as:
+# 1) TLS SNI for backend connection
+# 2) HTTP Host header for backend request routing
+# Required only when reverse_proxy_url host is an IP address.
+reverse_proxy_hostname = "example.com"
+# Per-request timeout for backend proxying
+request_timeout = "10s"
+# Skip TLS verification for backend target (use only for local/self-signed backends)
+skip_backend_tls_verify = false
+
 [restful]
 # Address to bind RESTful API server
 addr = "127.0.0.1:8443"

--- a/tuic-server/src/camouflage.rs
+++ b/tuic-server/src/camouflage.rs
@@ -1,0 +1,202 @@
+use std::sync::Arc;
+
+use axum::http::{
+	HeaderName, Request, Response, Uri,
+	header::{HOST, HeaderValue},
+};
+use bytes::{Buf, Bytes};
+use futures_util::StreamExt;
+use h3::server;
+use quinn::Connection;
+use reqwest::{Client, Method, Url};
+use tracing::{debug, info, warn};
+
+use crate::{AppContext, config::CamouflageConfig, h3_quinn_compat};
+
+const MAX_REQUEST_BODY_SIZE: usize = 16 * 1024 * 1024;
+const MAX_RESPONSE_BODY_SIZE: usize = 64 * 1024 * 1024;
+
+pub async fn handle(
+	ctx: Arc<AppContext>,
+	conn: Connection,
+	prefetched_uni: Option<h3_quinn_compat::PeekableRecvStream>,
+	prefetched_bi: Option<h3_quinn_compat::PrefetchedBiRecv>,
+) -> eyre::Result<()> {
+	let Some(camouflage) = ctx.cfg.camouflage.as_ref().filter(|cfg| cfg.enabled) else {
+		return Ok(());
+	};
+
+	let (backend, backend_host_override, client) = build_backend_route(camouflage)?;
+
+	info!(
+		"[{id:#010x}] [{addr}] [camouflage] HTTP/3 camouflage enabled, reverse proxy target={target}, backend_host={host:?}",
+		id = conn.stable_id() as u32,
+		addr = conn.remote_address(),
+		target = backend,
+		host = backend_host_override
+	);
+
+	let quic_conn = h3_quinn_compat::Connection::new_with_prefetched(conn, prefetched_uni, prefetched_bi);
+	let mut h3_conn = server::Connection::new(quic_conn).await?;
+
+	while let Some(resolver) = h3_conn.accept().await? {
+		let (request, mut stream) = resolver.resolve_request().await?;
+		debug!(
+			"[camouflage] incoming h3 request: method={} uri={}",
+			request.method(),
+			request.uri()
+		);
+
+		match forward_request(&client, &backend, backend_host_override.as_deref(), request, &mut stream).await {
+			Ok(()) => {}
+			Err(err) => {
+				warn!("[camouflage] request forwarding failed: {err}");
+				let resp = Response::builder().status(502).body(())?;
+				_ = stream.send_response(resp).await;
+				_ = stream.finish().await;
+			}
+		}
+	}
+
+	Ok(())
+}
+
+fn build_backend_route(camouflage: &CamouflageConfig) -> eyre::Result<(Url, Option<String>, Client)> {
+	let mut backend = Url::parse(camouflage.reverse_proxy_url.as_str())?;
+	let backend_host = backend
+		.host_str()
+		.ok_or_else(|| eyre::eyre!("`camouflage.reverse_proxy_url` must contain a host"))?
+		.to_string();
+	let backend_port = backend
+		.port_or_known_default()
+		.ok_or_else(|| eyre::eyre!("`camouflage.reverse_proxy_url` has no known port"))?;
+
+	let mut client_builder = Client::builder()
+		.danger_accept_invalid_certs(camouflage.skip_backend_tls_verify)
+		.timeout(camouflage.request_timeout);
+	let mut backend_host_override = camouflage.reverse_proxy_hostname.clone();
+
+	if let Some(reverse_proxy_hostname) = camouflage.reverse_proxy_hostname.as_deref() {
+		backend
+			.set_host(Some(reverse_proxy_hostname))
+			.map_err(|_| eyre::eyre!("invalid `camouflage.reverse_proxy_hostname`: {reverse_proxy_hostname}"))?;
+		if let Ok(ip) = backend_host.parse::<std::net::IpAddr>() {
+			client_builder = client_builder.resolve(reverse_proxy_hostname, std::net::SocketAddr::new(ip, backend_port));
+		}
+		backend_host_override = Some(reverse_proxy_hostname.to_string());
+	}
+
+	let client = client_builder.build()?;
+	Ok((backend, backend_host_override, client))
+}
+
+async fn forward_request<S>(
+	client: &Client,
+	backend: &Url,
+	backend_host_override: Option<&str>,
+	request: Request<()>,
+	stream: &mut server::RequestStream<S, Bytes>,
+) -> eyre::Result<()>
+where
+	S: h3::quic::BidiStream<Bytes>,
+{
+	let target = rewrite_target_url(backend, request.uri())?;
+	let method = Method::from_bytes(request.method().as_str().as_bytes())?;
+	let mut backend_request = client.request(method, target);
+
+	for (name, value) in request.headers() {
+		if is_forwardable_header(name) {
+			backend_request = backend_request.header(name, value);
+		}
+	}
+	if let Some(host) = backend_host_override {
+		backend_request = backend_request.header(HOST, host);
+	} else if let Some(host) = request
+		.headers()
+		.get(HOST)
+		.and_then(|h| HeaderValue::from_bytes(h.as_bytes()).ok())
+	{
+		backend_request = backend_request.header(HOST, host);
+	}
+
+	let request_body = read_request_body(stream).await?;
+	if !request_body.is_empty() {
+		backend_request = backend_request.body(request_body);
+	}
+
+	let backend_response = backend_request.send().await?;
+	let status = backend_response.status();
+	let headers = backend_response.headers().clone();
+
+	let mut response = Response::builder().status(status);
+	for (name, value) in &headers {
+		if is_forwardable_header(name) {
+			response = response.header(name, value);
+		}
+	}
+	let response = response.body(())?;
+	stream.send_response(response).await?;
+
+	let mut body_size = 0usize;
+	let mut body_stream = backend_response.bytes_stream();
+	while let Some(chunk) = body_stream.next().await {
+		let chunk = chunk?;
+		body_size += chunk.len();
+		if body_size > MAX_RESPONSE_BODY_SIZE {
+			return Err(eyre::eyre!(
+				"response body too large: {} bytes (max {})",
+				body_size,
+				MAX_RESPONSE_BODY_SIZE
+			));
+		}
+		if !chunk.is_empty() {
+			stream.send_data(chunk).await?;
+		}
+	}
+	stream.finish().await?;
+	Ok(())
+}
+
+async fn read_request_body<S>(stream: &mut server::RequestStream<S, Bytes>) -> eyre::Result<Bytes>
+where
+	S: h3::quic::BidiStream<Bytes>,
+{
+	let mut body = Vec::new();
+
+	while let Some(mut chunk) = stream.recv_data().await? {
+		let remaining = chunk.remaining();
+		body.extend_from_slice(chunk.copy_to_bytes(remaining).as_ref());
+		if body.len() > MAX_REQUEST_BODY_SIZE {
+			return Err(eyre::eyre!(
+				"request body too large: {} bytes (max {})",
+				body.len(),
+				MAX_REQUEST_BODY_SIZE
+			));
+		}
+	}
+	let _ = stream.recv_trailers().await?;
+
+	Ok(Bytes::from(body))
+}
+
+fn rewrite_target_url(backend: &Url, uri: &Uri) -> eyre::Result<Url> {
+	let mut target = backend.clone();
+	let path_and_query = uri.path_and_query().map(|v| v.as_str()).unwrap_or("/");
+	target.set_path("");
+	target.set_query(None);
+	let target = target.join(path_and_query)?;
+	Ok(target)
+}
+
+fn is_forwardable_header(name: &HeaderName) -> bool {
+	!matches!(
+		name.as_str().to_ascii_lowercase().as_str(),
+		"connection"
+			| "keep-alive"
+			| "proxy-connection"
+			| "transfer-encoding"
+			| "upgrade"
+			| "te" | "trailer"
+			| "host" | "content-length"
+	)
+}

--- a/tuic-server/src/camouflage.rs
+++ b/tuic-server/src/camouflage.rs
@@ -11,7 +11,7 @@ use quinn::Connection;
 use reqwest::{Client, Method, Url};
 use tracing::{debug, info, warn};
 
-use crate::{AppContext, config::CamouflageConfig, h3_quinn_compat};
+use crate::{AppContext, config::CamouflageConfig};
 
 const MAX_REQUEST_BODY_SIZE: usize = 16 * 1024 * 1024;
 const MAX_RESPONSE_BODY_SIZE: usize = 64 * 1024 * 1024;
@@ -19,8 +19,8 @@ const MAX_RESPONSE_BODY_SIZE: usize = 64 * 1024 * 1024;
 pub async fn handle(
 	ctx: Arc<AppContext>,
 	conn: Connection,
-	prefetched_uni: Option<h3_quinn_compat::PeekableRecvStream>,
-	prefetched_bi: Option<h3_quinn_compat::PrefetchedBiRecv>,
+	prefetched_uni: Option<crate::h3_quinn_compat::PeekableRecvStream>,
+	prefetched_bi: Option<crate::h3_quinn_compat::PrefetchedBiRecv>,
 ) -> eyre::Result<()> {
 	let Some(camouflage) = ctx.cfg.camouflage.as_ref().filter(|cfg| cfg.enabled) else {
 		return Ok(());
@@ -36,7 +36,7 @@ pub async fn handle(
 		host = backend_host_override
 	);
 
-	let quic_conn = h3_quinn_compat::Connection::new_with_prefetched(conn, prefetched_uni, prefetched_bi);
+	let quic_conn = crate::h3_quinn_compat::Connection::new_with_prefetched(conn, prefetched_uni, prefetched_bi);
 	let mut h3_conn = server::Connection::new(quic_conn).await?;
 
 	while let Some(resolver) = h3_conn.accept().await? {

--- a/tuic-server/src/config.rs
+++ b/tuic-server/src/config.rs
@@ -13,6 +13,7 @@ use figment::{
 };
 use figment_json5::Json5;
 use rand::{RngExt, distr::Alphanumeric, rng};
+use reqwest::Url;
 use serde::{Deserialize, Deserializer, Serialize};
 use tracing::{level_filters::LevelFilter, warn};
 use uuid::Uuid;
@@ -78,11 +79,13 @@ pub struct Cli {
 #[educe(Default)]
 #[serde(default, deny_unknown_fields)]
 pub struct Config {
-	pub log_level: LogLevel,
+	pub log_level:  LogLevel,
 	#[educe(Default(expression = "[::]:8443".parse().unwrap()))]
-	pub server:    SocketAddr,
-	pub users:     HashMap<Uuid, String>,
-	pub tls:       TlsConfig,
+	pub server:     SocketAddr,
+	pub users:      HashMap<Uuid, String>,
+	pub tls:        TlsConfig,
+	#[educe(Default = None)]
+	pub camouflage: Option<CamouflageConfig>,
 
 	#[educe(Default = "")]
 	pub data_dir: PathBuf,
@@ -237,6 +240,23 @@ pub struct QuicConfig {
 	#[serde(with = "humantime_serde")]
 	#[educe(Default(expression = Duration::from_secs(30)))]
 	pub max_idle_time: Duration,
+}
+
+#[derive(Deserialize, Serialize, Educe, Clone, Debug)]
+#[educe(Default)]
+#[serde(default, deny_unknown_fields)]
+pub struct CamouflageConfig {
+	#[educe(Default = false)]
+	pub enabled:                 bool,
+	#[educe(Default(expression = "".to_string()))]
+	pub reverse_proxy_url:       String,
+	#[educe(Default = None)]
+	pub reverse_proxy_hostname:  Option<String>,
+	#[serde(with = "humantime_serde")]
+	#[educe(Default(expression = Duration::from_secs(10)))]
+	pub request_timeout:         Duration,
+	#[educe(Default = false)]
+	pub skip_backend_tls_verify: bool,
 }
 
 /// The `default` rule is mandatory when named rules are present; other named
@@ -763,6 +783,40 @@ pub async fn parse_config(cli: Cli, env_state: EnvState) -> eyre::Result<Config>
 		config.tls.private_key.clone()
 	};
 
+	if let Some(camouflage) = &config.camouflage
+		&& camouflage.enabled
+	{
+		if camouflage.reverse_proxy_url.trim().is_empty() {
+			return Err(eyre::eyre!(
+				"`camouflage.reverse_proxy_url` is required when camouflage is enabled"
+			));
+		}
+		if !camouflage.reverse_proxy_url.starts_with("http://") && !camouflage.reverse_proxy_url.starts_with("https://") {
+			return Err(eyre::eyre!(
+				"`camouflage.reverse_proxy_url` must be an absolute URL and start with http:// or https://"
+			));
+		}
+		if camouflage
+			.reverse_proxy_hostname
+			.as_deref()
+			.is_some_and(|s| s.trim().is_empty())
+		{
+			return Err(eyre::eyre!("`camouflage.reverse_proxy_hostname` cannot be empty"));
+		}
+		let backend = Url::parse(camouflage.reverse_proxy_url.as_str())
+			.map_err(|err| eyre::eyre!("`camouflage.reverse_proxy_url` is invalid: {err}"))?;
+		if backend
+			.host_str()
+			.and_then(|host| host.parse::<std::net::IpAddr>().ok())
+			.is_some()
+			&& camouflage.reverse_proxy_hostname.is_none()
+		{
+			return Err(eyre::eyre!(
+				"`camouflage.reverse_proxy_hostname` is required when `camouflage.reverse_proxy_url` uses an IP address"
+			));
+		}
+	}
+
 	Ok(config)
 }
 
@@ -816,6 +870,13 @@ mod tests {
 		assert!(result.tls.auto_ssl);
 		assert_eq!(result.tls.hostname, "testhost");
 		assert_eq!(result.tls.acme_email, "admin@example.com");
+		assert!(result.camouflage.is_some());
+		let camouflage = result.camouflage.as_ref().unwrap();
+		assert!(camouflage.enabled);
+		assert_eq!(camouflage.reverse_proxy_url, "https://127.0.0.1:443");
+		assert_eq!(camouflage.reverse_proxy_hostname.as_deref(), Some("example.com"));
+		assert_eq!(camouflage.request_timeout, Duration::from_secs(15));
+		assert!(camouflage.skip_backend_tls_verify);
 		assert_eq!(result.quic.initial_mtu, 1400);
 		assert_eq!(result.quic.min_mtu, 1300);
 		assert_eq!(result.quic.send_window, 10000000);
@@ -930,6 +991,44 @@ mod tests {
 		assert!(result.is_ok());
 		let cli = result.unwrap();
 		assert!(cli.config.is_none());
+	}
+
+	#[tokio::test]
+	async fn test_camouflage_invalid_reverse_proxy_url() {
+		let config = r#"
+server = "127.0.0.1:8080"
+
+[tls]
+self_sign = true
+
+[users]
+"123e4567-e89b-12d3-a456-426614174000" = "password1"
+
+[camouflage]
+enabled = true
+reverse_proxy_url = "127.0.0.1:443"
+"#;
+		let result = test_parse_config(config, ".toml").await;
+		assert!(result.is_err());
+	}
+
+	#[tokio::test]
+	async fn test_camouflage_ip_reverse_proxy_url_requires_reverse_proxy_hostname() {
+		let config = r#"
+server = "127.0.0.1:8080"
+
+[tls]
+self_sign = true
+
+[users]
+"123e4567-e89b-12d3-a456-426614174000" = "password1"
+
+[camouflage]
+enabled = true
+reverse_proxy_url = "https://127.0.0.1:443"
+"#;
+		let result = test_parse_config(config, ".toml").await;
+		assert!(result.is_err());
 	}
 
 	#[tokio::test]

--- a/tuic-server/src/connection/handle_stream.rs
+++ b/tuic-server/src/connection/handle_stream.rs
@@ -10,8 +10,27 @@ use tuic_core::quinn::Task;
 use super::Connection;
 use crate::{error::Error, utils::UdpRelayMode};
 
+enum UniStreamSource {
+	Normal(RecvStream),
+	Prefetched(RecvStream, Bytes),
+}
+
+enum BiStreamSource {
+	Normal(SendStream, RecvStream),
+	Prefetched(SendStream, RecvStream, Bytes),
+}
+
 impl Connection {
 	pub async fn handle_uni_stream(self, recv: RecvStream, reg: Register) {
+		self.handle_uni_stream_inner(UniStreamSource::Normal(recv), reg).await;
+	}
+
+	pub async fn handle_uni_stream_prefixed(self, recv: RecvStream, prefix: Bytes, reg: Register) {
+		self.handle_uni_stream_inner(UniStreamSource::Prefetched(recv, prefix), reg)
+			.await;
+	}
+
+	async fn handle_uni_stream_inner(self, source: UniStreamSource, reg: Register) {
 		debug!(
 			"[{id:#010x}] [{addr}] [{user}] incoming unidirectional stream",
 			id = self.id(),
@@ -19,27 +38,22 @@ impl Connection {
 			user = self.auth,
 		);
 
-		let current_max = self.max_concurrent_uni_streams.load(Ordering::Relaxed);
-
-		if self.remote_uni_stream_cnt.count() >= (current_max as f32 * 0.7) as usize
-			&& let Ok(_) = self.max_concurrent_uni_streams.compare_exchange(
-				current_max,
-				current_max * 2,
-				Ordering::AcqRel,
-				Ordering::Acquire,
-			) {
-			debug!(
-				"[{id:#010x}] reached max concurrent uni_streams, setting bigger limitation={num}",
-				id = self.id(),
-				num = current_max * 2
-			);
-			self.inner.set_max_concurrent_uni_streams(VarInt::from(current_max * 2));
-		}
+		self.maybe_expand_uni_stream_limit();
 
 		let pre_process = async {
-			let task = time::timeout(self.ctx.cfg.task_negotiation_timeout, self.model.accept_uni_stream(recv))
+			let task = match source {
+				UniStreamSource::Normal(recv) => {
+					time::timeout(self.ctx.cfg.task_negotiation_timeout, self.model.accept_uni_stream(recv))
+						.await
+						.map_err(|_| Error::TaskNegotiationTimeout)??
+				}
+				UniStreamSource::Prefetched(recv, prefix) => time::timeout(
+					self.ctx.cfg.task_negotiation_timeout,
+					self.model.accept_uni_stream_prefixed(recv, prefix),
+				)
 				.await
-				.map_err(|_| Error::TaskNegotiationTimeout)??;
+				.map_err(|_| Error::TaskNegotiationTimeout)??,
+			};
 
 			if let Task::Authenticate(auth) = &task {
 				self.authenticate(auth).await?;
@@ -81,6 +95,15 @@ impl Connection {
 	}
 
 	pub async fn handle_bi_stream(self, (send, recv): (SendStream, RecvStream), reg: Register) {
+		self.handle_bi_stream_inner(BiStreamSource::Normal(send, recv), reg).await;
+	}
+
+	pub async fn handle_bi_stream_prefixed(self, (send, recv): (SendStream, RecvStream), prefix: Bytes, reg: Register) {
+		self.handle_bi_stream_inner(BiStreamSource::Prefetched(send, recv, prefix), reg)
+			.await;
+	}
+
+	async fn handle_bi_stream_inner(self, source: BiStreamSource, reg: Register) {
 		debug!(
 			"[{id:#010x}] [{addr}] [{user}] incoming bidirectional stream",
 			id = self.id(),
@@ -88,27 +111,22 @@ impl Connection {
 			user = self.auth,
 		);
 
-		let current_max = self.max_concurrent_bi_streams.load(Ordering::Relaxed);
-
-		if self.remote_bi_stream_cnt.count() >= (current_max as f32 * 0.7) as usize
-			&& let Ok(_) = self.max_concurrent_bi_streams.compare_exchange(
-				current_max,
-				current_max * 2,
-				Ordering::AcqRel,
-				Ordering::Acquire,
-			) {
-			debug!(
-				"[{id:#010x}] reached max concurrent bi_streams, setting bigger limitation={num}",
-				id = self.id(),
-				num = current_max * 2
-			);
-			self.inner.set_max_concurrent_bi_streams(VarInt::from(current_max * 2));
-		}
+		self.maybe_expand_bi_stream_limit();
 
 		let pre_process = async {
-			let task = time::timeout(self.ctx.cfg.task_negotiation_timeout, self.model.accept_bi_stream(send, recv))
+			let task = match source {
+				BiStreamSource::Normal(send, recv) => {
+					time::timeout(self.ctx.cfg.task_negotiation_timeout, self.model.accept_bi_stream(send, recv))
+						.await
+						.map_err(|_| Error::TaskNegotiationTimeout)??
+				}
+				BiStreamSource::Prefetched(send, recv, prefix) => time::timeout(
+					self.ctx.cfg.task_negotiation_timeout,
+					self.model.accept_bi_stream_prefixed(send, recv, prefix),
+				)
 				.await
-				.map_err(|_| Error::TaskNegotiationTimeout)??;
+				.map_err(|_| Error::TaskNegotiationTimeout)??,
+			};
 
 			// Fast path: if already authenticated, skip the select
 			if !self.auth.is_authenticated() {
@@ -135,6 +153,44 @@ impl Connection {
 			}
 		}
 		drop(reg);
+	}
+
+	fn maybe_expand_uni_stream_limit(&self) {
+		let current_max = self.max_concurrent_uni_streams.load(Ordering::Relaxed);
+
+		if self.remote_uni_stream_cnt.count() >= (current_max as f32 * 0.7) as usize
+			&& let Ok(_) = self.max_concurrent_uni_streams.compare_exchange(
+				current_max,
+				current_max * 2,
+				Ordering::AcqRel,
+				Ordering::Acquire,
+			) {
+			debug!(
+				"[{id:#010x}] reached max concurrent uni_streams, setting bigger limitation={num}",
+				id = self.id(),
+				num = current_max * 2
+			);
+			self.inner.set_max_concurrent_uni_streams(VarInt::from(current_max * 2));
+		}
+	}
+
+	fn maybe_expand_bi_stream_limit(&self) {
+		let current_max = self.max_concurrent_bi_streams.load(Ordering::Relaxed);
+
+		if self.remote_bi_stream_cnt.count() >= (current_max as f32 * 0.7) as usize
+			&& let Ok(_) = self.max_concurrent_bi_streams.compare_exchange(
+				current_max,
+				current_max * 2,
+				Ordering::AcqRel,
+				Ordering::Acquire,
+			) {
+			debug!(
+				"[{id:#010x}] reached max concurrent bi_streams, setting bigger limitation={num}",
+				id = self.id(),
+				num = current_max * 2
+			);
+			self.inner.set_max_concurrent_bi_streams(VarInt::from(current_max * 2));
+		}
 	}
 
 	pub async fn handle_datagram(self, dg: Bytes) {

--- a/tuic-server/src/connection/handle_stream.rs
+++ b/tuic-server/src/connection/handle_stream.rs
@@ -1,36 +1,17 @@
 use std::sync::atomic::Ordering;
 
 use bytes::Bytes;
-use quinn::{RecvStream, SendStream, VarInt};
+use quinn::VarInt;
 use register_count::Register;
 use tokio::time;
 use tracing::{debug, warn};
-use tuic_core::quinn::Task;
+use tuic_core::quinn::{StreamRx, StreamTx, Task};
 
 use super::Connection;
 use crate::{error::Error, utils::UdpRelayMode};
 
-enum UniStreamSource {
-	Normal(RecvStream),
-	Prefetched(RecvStream, Bytes),
-}
-
-enum BiStreamSource {
-	Normal(SendStream, RecvStream),
-	Prefetched(SendStream, RecvStream, Bytes),
-}
-
 impl Connection {
-	pub async fn handle_uni_stream(self, recv: RecvStream, reg: Register) {
-		self.handle_uni_stream_inner(UniStreamSource::Normal(recv), reg).await;
-	}
-
-	pub async fn handle_uni_stream_prefixed(self, recv: RecvStream, prefix: Bytes, reg: Register) {
-		self.handle_uni_stream_inner(UniStreamSource::Prefetched(recv, prefix), reg)
-			.await;
-	}
-
-	async fn handle_uni_stream_inner(self, source: UniStreamSource, reg: Register) {
+	pub async fn handle_uni_stream<R: StreamRx>(self, recv: R, reg: Register) {
 		debug!(
 			"[{id:#010x}] [{addr}] [{user}] incoming unidirectional stream",
 			id = self.id(),
@@ -41,25 +22,14 @@ impl Connection {
 		self.maybe_expand_uni_stream_limit();
 
 		let pre_process = async {
-			let task = match source {
-				UniStreamSource::Normal(recv) => {
-					time::timeout(self.ctx.cfg.task_negotiation_timeout, self.model.accept_uni_stream(recv))
-						.await
-						.map_err(|_| Error::TaskNegotiationTimeout)??
-				}
-				UniStreamSource::Prefetched(recv, prefix) => time::timeout(
-					self.ctx.cfg.task_negotiation_timeout,
-					self.model.accept_uni_stream_prefixed(recv, prefix),
-				)
+			let task = time::timeout(self.ctx.cfg.task_negotiation_timeout, self.model.accept_uni_stream(recv))
 				.await
-				.map_err(|_| Error::TaskNegotiationTimeout)??,
-			};
+				.map_err(|_| Error::TaskNegotiationTimeout)??;
 
 			if let Task::Authenticate(auth) = &task {
 				self.authenticate(auth).await?;
 			}
 
-			// Fast path: if already authenticated, skip the select
 			if !self.auth.is_authenticated() {
 				tokio::select! {
 					() = self.auth.wait() => {}
@@ -67,9 +37,7 @@ impl Connection {
 				};
 			}
 
-			let same_pkt_src =
-				matches!(task, Task::Packet(_)) && matches!(**self.udp_relay_mode.load(), Some(UdpRelayMode::Native));
-			if same_pkt_src {
+			if matches!(task, Task::Packet(_)) && matches!(**self.udp_relay_mode.load(), Some(UdpRelayMode::Native)) {
 				return Err(Error::UnexpectedPacketSource);
 			}
 
@@ -80,7 +48,7 @@ impl Connection {
 			Ok(Task::Authenticate(auth)) => self.handle_authenticate(auth).await,
 			Ok(Task::Packet(pkt)) => self.handle_packet(pkt, UdpRelayMode::Quic).await,
 			Ok(Task::Dissociate(assoc_id)) => self.handle_dissociate(assoc_id).await,
-			Ok(_) => unreachable!(), // already filtered in `tuic_quinn`
+			Ok(_) => unreachable!(),
 			Err(err) => {
 				warn!(
 					"[{id:#010x}] [{addr}] [{user}] handling incoming unidirectional stream error: {err}",
@@ -94,16 +62,7 @@ impl Connection {
 		drop(reg);
 	}
 
-	pub async fn handle_bi_stream(self, (send, recv): (SendStream, RecvStream), reg: Register) {
-		self.handle_bi_stream_inner(BiStreamSource::Normal(send, recv), reg).await;
-	}
-
-	pub async fn handle_bi_stream_prefixed(self, (send, recv): (SendStream, RecvStream), prefix: Bytes, reg: Register) {
-		self.handle_bi_stream_inner(BiStreamSource::Prefetched(send, recv, prefix), reg)
-			.await;
-	}
-
-	async fn handle_bi_stream_inner(self, source: BiStreamSource, reg: Register) {
+	pub async fn handle_bi_stream<S: StreamTx, R: StreamRx>(self, (send, recv): (S, R), reg: Register) {
 		debug!(
 			"[{id:#010x}] [{addr}] [{user}] incoming bidirectional stream",
 			id = self.id(),
@@ -114,21 +73,10 @@ impl Connection {
 		self.maybe_expand_bi_stream_limit();
 
 		let pre_process = async {
-			let task = match source {
-				BiStreamSource::Normal(send, recv) => {
-					time::timeout(self.ctx.cfg.task_negotiation_timeout, self.model.accept_bi_stream(send, recv))
-						.await
-						.map_err(|_| Error::TaskNegotiationTimeout)??
-				}
-				BiStreamSource::Prefetched(send, recv, prefix) => time::timeout(
-					self.ctx.cfg.task_negotiation_timeout,
-					self.model.accept_bi_stream_prefixed(send, recv, prefix),
-				)
+			let task = time::timeout(self.ctx.cfg.task_negotiation_timeout, self.model.accept_bi_stream(send, recv))
 				.await
-				.map_err(|_| Error::TaskNegotiationTimeout)??,
-			};
+				.map_err(|_| Error::TaskNegotiationTimeout)??;
 
-			// Fast path: if already authenticated, skip the select
 			if !self.auth.is_authenticated() {
 				tokio::select! {
 					() = self.auth.wait() => {}
@@ -141,7 +89,7 @@ impl Connection {
 
 		match pre_process.await {
 			Ok(Task::Connect(conn)) => self.handle_connect(conn).await,
-			Ok(_) => unreachable!(), // already filtered in `tuic_quinn`
+			Ok(_) => unreachable!(),
 			Err(err) => {
 				warn!(
 					"[{id:#010x}] [{addr}] [{user}] handling incoming bidirectional stream error: {err}",
@@ -204,7 +152,6 @@ impl Connection {
 		let pre_process = async {
 			let task = self.model.accept_datagram(dg)?;
 
-			// Fast path: if already authenticated, skip the select
 			if !self.auth.is_authenticated() {
 				tokio::select! {
 					() = self.auth.wait() => {}
@@ -212,9 +159,7 @@ impl Connection {
 				};
 			}
 
-			let same_pkt_src =
-				matches!(task, Task::Packet(_)) && matches!(**self.udp_relay_mode.load(), Some(UdpRelayMode::Quic));
-			if same_pkt_src {
+			if matches!(task, Task::Packet(_)) && matches!(**self.udp_relay_mode.load(), Some(UdpRelayMode::Quic)) {
 				return Err(Error::UnexpectedPacketSource);
 			}
 

--- a/tuic-server/src/connection/handle_task.rs
+++ b/tuic-server/src/connection/handle_task.rs
@@ -14,7 +14,7 @@ use tokio::{
 use tracing::{info, warn};
 use tuic_core::{
 	Address, is_private_ip,
-	quinn::{Authenticate, Connect, Packet},
+	quinn::{Authenticate, Connect, Packet, StreamRx, StreamTx},
 };
 
 use super::{Connection, ERROR_CODE, UdpSession};
@@ -186,7 +186,7 @@ impl Connection {
 		);
 	}
 
-	pub async fn handle_connect(&self, mut conn: Connect) {
+	pub async fn handle_connect<S: StreamTx, R: StreamRx>(&self, mut conn: Connect<S, R>) {
 		let target_addr = conn.addr().to_string();
 
 		info!(
@@ -319,7 +319,7 @@ impl Connection {
 			.unwrap_or_else(|| eyre!("Failed to connect to any address")))
 	}
 
-	pub async fn handle_packet(&self, pkt: Packet, mode: UdpRelayMode) {
+	pub async fn handle_packet<R: StreamRx>(&self, pkt: Packet<R>, mode: UdpRelayMode) {
 		let assoc_id = pkt.assoc_id();
 		let pkt_id = pkt.pkt_id();
 		let frag_id = pkt.frag_id();

--- a/tuic-server/src/connection/mod.rs
+++ b/tuic-server/src/connection/mod.rs
@@ -5,6 +5,8 @@ use std::{
 };
 
 use arc_swap::ArcSwap;
+use bytes::Bytes;
+use peekable::future::AsyncPeekExt;
 use quinn::{Connecting, Connection as QuinnConnection, VarInt};
 use register_count::Counter;
 use tokio::{sync::RwLock as AsyncRwLock, time};
@@ -12,7 +14,7 @@ use tracing::{debug, info, warn};
 use tuic_core::quinn::{Authenticate, Connection as Model, side};
 
 use self::{authenticated::Authenticated, udp_session::UdpSession};
-use crate::{AppContext, error::Error, restful, utils::UdpRelayMode};
+use crate::{AppContext, camouflage, error::Error, h3_quinn_compat, restful, utils::UdpRelayMode};
 
 mod authenticated;
 mod handle_stream;
@@ -21,6 +23,38 @@ mod udp_session;
 
 pub const ERROR_CODE: VarInt = VarInt::from_u32(0);
 pub const INIT_CONCURRENT_STREAMS: u32 = 512;
+
+enum H3Dispatch {
+	Tuic(Option<PrefetchedFirstEventTuic>),
+	Camouflage {
+		prefetched_uni: Option<h3_quinn_compat::PeekableRecvStream>,
+		prefetched_bi:  Option<h3_quinn_compat::PrefetchedBiRecv>,
+	},
+}
+
+enum FirstEvent {
+	Uni(quinn::RecvStream),
+	Bi(quinn::SendStream, quinn::RecvStream),
+	Datagram(Bytes),
+}
+
+enum ClassifiedRecvStream {
+	Tuic { recv: quinn::RecvStream, prefix: Bytes },
+	Camouflage(h3_quinn_compat::PeekableRecvStream),
+}
+
+enum PrefetchedFirstEventTuic {
+	Uni {
+		recv:   quinn::RecvStream,
+		prefix: Bytes,
+	},
+	Bi {
+		send:   quinn::SendStream,
+		recv:   quinn::RecvStream,
+		prefix: Bytes,
+	},
+	Datagram(Bytes),
+}
 
 #[derive(Clone)]
 pub struct Connection {
@@ -55,6 +89,60 @@ impl Connection {
 
 		match init.await {
 			Ok(conn) => {
+				if ctx.cfg.camouflage.as_ref().is_some_and(|cfg| cfg.enabled) {
+					match conn.classify_h3_dispatch().await {
+						Ok(H3Dispatch::Camouflage {
+							prefetched_uni,
+							prefetched_bi,
+						}) => {
+							if let Err(err) =
+								camouflage::handle(ctx.clone(), conn.inner.clone(), prefetched_uni, prefetched_bi).await
+							{
+								warn!("[{id:#010x}] [{addr}] [camouflage] {err}", id = conn.id(), addr = addr);
+							}
+							return;
+						}
+						Ok(H3Dispatch::Tuic(first_event)) => {
+							info!(
+								"[{id:#010x}] [{addr}] [{user}] connection established",
+								id = conn.id(),
+								user = conn.auth,
+							);
+							tokio::spawn(conn.clone().timeout_authenticate(ctx.cfg.auth_timeout));
+							tokio::spawn(conn.clone().collect_garbage());
+							if let Some(first_event) = first_event {
+								match first_event {
+									PrefetchedFirstEventTuic::Uni { recv, prefix } => {
+										tokio::spawn(conn.clone().handle_uni_stream_prefixed(
+											recv,
+											prefix,
+											conn.remote_uni_stream_cnt.reg(),
+										));
+									}
+									PrefetchedFirstEventTuic::Bi { send, recv, prefix } => {
+										tokio::spawn(conn.clone().handle_bi_stream_prefixed(
+											(send, recv),
+											prefix,
+											conn.remote_bi_stream_cnt.reg(),
+										));
+									}
+									PrefetchedFirstEventTuic::Datagram(dg) => {
+										tokio::spawn(conn.clone().handle_datagram(dg));
+									}
+								}
+							}
+
+							conn.run_tuic_event_loop().await;
+							return;
+						}
+						Err(err) => {
+							warn!("[{id:#010x}] [{addr}] [classifier] {err}", id = conn.id(), addr = addr);
+							conn.close();
+							return;
+						}
+					}
+				}
+
 				info!(
 					"[{id:#010x}] [{addr}] [{user}] connection established",
 					id = conn.id(),
@@ -62,37 +150,7 @@ impl Connection {
 				);
 				tokio::spawn(conn.clone().timeout_authenticate(ctx.cfg.auth_timeout));
 				tokio::spawn(conn.clone().collect_garbage());
-
-				loop {
-					if conn.is_closed() {
-						break;
-					}
-
-					let handle_incoming = async {
-						tokio::select! {
-							res = conn.inner.accept_uni() =>
-								tokio::spawn(conn.clone().handle_uni_stream(res?, conn.remote_uni_stream_cnt.reg())),
-							res = conn.inner.accept_bi() =>
-								tokio::spawn(conn.clone().handle_bi_stream(res?, conn.remote_bi_stream_cnt.reg())),
-							res = conn.inner.read_datagram() =>
-								tokio::spawn(conn.clone().handle_datagram(res?)),
-						};
-
-						Ok::<_, Error>(())
-					};
-
-					match handle_incoming.await {
-						Ok(()) => {}
-						Err(err) if err.is_trivial() => {
-							debug!("[{id:#010x}] [{addr}] [{user}] {err}", id = conn.id(), user = conn.auth,);
-						}
-						Err(err) => warn!(
-							"[{id:#010x}] [{addr}] [{user}] connection error: {err}",
-							id = conn.id(),
-							user = conn.auth,
-						),
-					}
-				}
+				conn.run_tuic_event_loop().await;
 			}
 			Err(err) if err.is_trivial() => {
 				debug!("[{id:#010x}] [{addr}] [unauthenticated] {err}", id = u32::MAX,);
@@ -176,6 +234,134 @@ impl Connection {
 
 	fn id(&self) -> u32 {
 		self.inner.stable_id() as u32
+	}
+
+	async fn classify_h3_dispatch(&self) -> Result<H3Dispatch, Error> {
+		let classify_timeout = self.ctx.cfg.task_negotiation_timeout;
+		let first_event = match time::timeout(classify_timeout, async {
+			tokio::select! {
+				res = self.inner.accept_uni() => {
+					let recv = res?;
+					Ok::<_, Error>(FirstEvent::Uni(recv))
+				}
+				res = self.inner.accept_bi() => {
+					let (send, recv) = res?;
+					Ok::<_, Error>(FirstEvent::Bi(send, recv))
+				}
+				res = self.inner.read_datagram() => {
+					let dg = res?;
+					Ok::<_, Error>(FirstEvent::Datagram(dg))
+				}
+			}
+		})
+		.await
+		{
+			Ok(Ok(event)) => event,
+			Ok(Err(err)) => return Err(err),
+			Err(_) => {
+				return Ok(H3Dispatch::Camouflage {
+					prefetched_uni: None,
+					prefetched_bi:  None,
+				});
+			}
+		};
+
+		match first_event {
+			FirstEvent::Uni(recv) => match self.classify_recv_stream(recv, classify_timeout).await? {
+				ClassifiedRecvStream::Tuic { recv, prefix } => {
+					Ok(H3Dispatch::Tuic(Some(PrefetchedFirstEventTuic::Uni { recv, prefix })))
+				}
+				ClassifiedRecvStream::Camouflage(recv) => Ok(H3Dispatch::Camouflage {
+					prefetched_uni: Some(recv),
+					prefetched_bi:  None,
+				}),
+			},
+			FirstEvent::Bi(send, recv) => match self.classify_recv_stream(recv, classify_timeout).await? {
+				ClassifiedRecvStream::Tuic { recv, prefix } => {
+					Ok(H3Dispatch::Tuic(Some(PrefetchedFirstEventTuic::Bi { send, recv, prefix })))
+				}
+				ClassifiedRecvStream::Camouflage(recv) => Ok(H3Dispatch::Camouflage {
+					prefetched_uni: None,
+					prefetched_bi:  Some(h3_quinn_compat::PrefetchedBiRecv { send, recv }),
+				}),
+			},
+			FirstEvent::Datagram(dg) => {
+				if self.is_tuic_datagram(&dg) {
+					Ok(H3Dispatch::Tuic(Some(PrefetchedFirstEventTuic::Datagram(dg))))
+				} else {
+					Ok(H3Dispatch::Camouflage {
+						prefetched_uni: None,
+						prefetched_bi:  None,
+					})
+				}
+			}
+		}
+	}
+
+	async fn classify_recv_stream(&self, recv: quinn::RecvStream, timeout: Duration) -> Result<ClassifiedRecvStream, Error> {
+		let mut recv = recv.peekable();
+		let mut prefix = [0u8; 2];
+		let read = time::timeout(timeout, recv.peek_exact(&mut prefix))
+			.await
+			.map_err(|_| Error::TaskNegotiationTimeout)?;
+		if let Err(err) = read {
+			return Err(Error::Other(eyre::eyre!("failed peeking classifier prefix: {err:?}")));
+		}
+
+		if self.is_tuic_prefix(prefix) {
+			let prefix = Bytes::from(recv.consume());
+			let (_, recv) = recv.into_components();
+			Ok(ClassifiedRecvStream::Tuic { recv, prefix })
+		} else {
+			Ok(ClassifiedRecvStream::Camouflage(recv))
+		}
+	}
+
+	fn is_tuic_prefix(&self, prefix: [u8; 2]) -> bool {
+		prefix[0] == tuic_core::VERSION && (prefix[1] <= tuic_core::Header::TYPE_CODE_HEARTBEAT)
+	}
+
+	fn is_tuic_datagram(&self, dg: &Bytes) -> bool {
+		dg.len() >= 2 && self.is_tuic_prefix([dg[0], dg[1]])
+	}
+
+	async fn run_tuic_event_loop(&self) {
+		loop {
+			if self.is_closed() {
+				break;
+			}
+
+			let handle_incoming = async {
+				tokio::select! {
+					res = self.inner.accept_uni() =>
+						tokio::spawn(self.clone().handle_uni_stream(res?, self.remote_uni_stream_cnt.reg())),
+					res = self.inner.accept_bi() =>
+						tokio::spawn(self.clone().handle_bi_stream(res?, self.remote_bi_stream_cnt.reg())),
+					res = self.inner.read_datagram() =>
+						tokio::spawn(self.clone().handle_datagram(res?)),
+				};
+
+				Ok::<_, Error>(())
+			};
+
+			match handle_incoming.await {
+				Ok(()) => {}
+				Err(err) if err.is_trivial() => {
+					debug!(
+						"[{id:#010x}] [{addr}] [{user}] {err}",
+						id = self.id(),
+						addr = self.inner.remote_address(),
+						user = self.auth,
+					);
+				}
+				Err(err) => warn!(
+					"[{id:#010x}] [{addr}] [{user}] connection error: {err}",
+					id = self.id(),
+					addr = self.inner.remote_address(),
+					user = self.auth,
+				),
+			}
+		}
 	}
 
 	fn is_closed(&self) -> bool {

--- a/tuic-server/src/connection/mod.rs
+++ b/tuic-server/src/connection/mod.rs
@@ -6,15 +6,16 @@ use std::{
 
 use arc_swap::ArcSwap;
 use bytes::Bytes;
-use peekable::future::AsyncPeekExt;
+use peekable::tokio::AsyncPeekExt;
 use quinn::{Connecting, Connection as QuinnConnection, VarInt};
 use register_count::Counter;
+use smallvec::SmallVec;
 use tokio::{sync::RwLock as AsyncRwLock, time};
 use tracing::{debug, info, warn};
 use tuic_core::quinn::{Authenticate, Connection as Model, side};
 
 use self::{authenticated::Authenticated, udp_session::UdpSession};
-use crate::{AppContext, camouflage, error::Error, h3_quinn_compat, restful, utils::UdpRelayMode};
+use crate::{AppContext, camouflage, error::Error, restful, utils::UdpRelayMode};
 
 mod authenticated;
 mod handle_stream;
@@ -27,8 +28,8 @@ pub const INIT_CONCURRENT_STREAMS: u32 = 512;
 enum H3Dispatch {
 	Tuic(Option<PrefetchedFirstEventTuic>),
 	Camouflage {
-		prefetched_uni: Option<h3_quinn_compat::PeekableRecvStream>,
-		prefetched_bi:  Option<h3_quinn_compat::PrefetchedBiRecv>,
+		prefetched_uni: Option<crate::h3_quinn_compat::PeekableRecvStream>,
+		prefetched_bi:  Option<crate::h3_quinn_compat::PrefetchedBiRecv>,
 	},
 }
 
@@ -39,19 +40,15 @@ enum FirstEvent {
 }
 
 enum ClassifiedRecvStream {
-	Tuic { recv: quinn::RecvStream, prefix: Bytes },
-	Camouflage(h3_quinn_compat::PeekableRecvStream),
+	Tuic(crate::h3_quinn_compat::PeekableRecvStream),
+	Camouflage(crate::h3_quinn_compat::PeekableRecvStream),
 }
 
 enum PrefetchedFirstEventTuic {
-	Uni {
-		recv:   quinn::RecvStream,
-		prefix: Bytes,
-	},
+	Uni(crate::h3_quinn_compat::PeekableRecvStream),
 	Bi {
-		send:   quinn::SendStream,
-		recv:   quinn::RecvStream,
-		prefix: Bytes,
+		send: quinn::SendStream,
+		recv: crate::h3_quinn_compat::PeekableRecvStream,
 	},
 	Datagram(Bytes),
 }
@@ -112,19 +109,13 @@ impl Connection {
 							tokio::spawn(conn.clone().collect_garbage());
 							if let Some(first_event) = first_event {
 								match first_event {
-									PrefetchedFirstEventTuic::Uni { recv, prefix } => {
-										tokio::spawn(conn.clone().handle_uni_stream_prefixed(
-											recv,
-											prefix,
-											conn.remote_uni_stream_cnt.reg(),
-										));
+									PrefetchedFirstEventTuic::Uni(recv) => {
+										tokio::spawn(conn.clone().handle_uni_stream(recv, conn.remote_uni_stream_cnt.reg()));
 									}
-									PrefetchedFirstEventTuic::Bi { send, recv, prefix } => {
-										tokio::spawn(conn.clone().handle_bi_stream_prefixed(
-											(send, recv),
-											prefix,
-											conn.remote_bi_stream_cnt.reg(),
-										));
+									PrefetchedFirstEventTuic::Bi { send, recv } => {
+										tokio::spawn(
+											conn.clone().handle_bi_stream((send, recv), conn.remote_bi_stream_cnt.reg()),
+										);
 									}
 									PrefetchedFirstEventTuic::Datagram(dg) => {
 										tokio::spawn(conn.clone().handle_datagram(dg));
@@ -268,21 +259,17 @@ impl Connection {
 
 		match first_event {
 			FirstEvent::Uni(recv) => match self.classify_recv_stream(recv, classify_timeout).await? {
-				ClassifiedRecvStream::Tuic { recv, prefix } => {
-					Ok(H3Dispatch::Tuic(Some(PrefetchedFirstEventTuic::Uni { recv, prefix })))
-				}
+				ClassifiedRecvStream::Tuic(recv) => Ok(H3Dispatch::Tuic(Some(PrefetchedFirstEventTuic::Uni(recv)))),
 				ClassifiedRecvStream::Camouflage(recv) => Ok(H3Dispatch::Camouflage {
 					prefetched_uni: Some(recv),
 					prefetched_bi:  None,
 				}),
 			},
 			FirstEvent::Bi(send, recv) => match self.classify_recv_stream(recv, classify_timeout).await? {
-				ClassifiedRecvStream::Tuic { recv, prefix } => {
-					Ok(H3Dispatch::Tuic(Some(PrefetchedFirstEventTuic::Bi { send, recv, prefix })))
-				}
+				ClassifiedRecvStream::Tuic(recv) => Ok(H3Dispatch::Tuic(Some(PrefetchedFirstEventTuic::Bi { send, recv }))),
 				ClassifiedRecvStream::Camouflage(recv) => Ok(H3Dispatch::Camouflage {
 					prefetched_uni: None,
-					prefetched_bi:  Some(h3_quinn_compat::PrefetchedBiRecv { send, recv }),
+					prefetched_bi:  Some(crate::h3_quinn_compat::PrefetchedBiRecv { send, recv }),
 				}),
 			},
 			FirstEvent::Datagram(dg) => {
@@ -299,7 +286,7 @@ impl Connection {
 	}
 
 	async fn classify_recv_stream(&self, recv: quinn::RecvStream, timeout: Duration) -> Result<ClassifiedRecvStream, Error> {
-		let mut recv = recv.peekable();
+		let mut recv = recv.peekable_with_buffer::<SmallVec<[u8; 4]>>();
 		let mut prefix = [0u8; 2];
 		let read = time::timeout(timeout, recv.peek_exact(&mut prefix))
 			.await
@@ -309,9 +296,7 @@ impl Connection {
 		}
 
 		if self.is_tuic_prefix(prefix) {
-			let prefix = Bytes::from(recv.consume());
-			let (_, recv) = recv.into_components();
-			Ok(ClassifiedRecvStream::Tuic { recv, prefix })
+			Ok(ClassifiedRecvStream::Tuic(recv))
 		} else {
 			Ok(ClassifiedRecvStream::Camouflage(recv))
 		}

--- a/tuic-server/src/h3_quinn_compat.rs
+++ b/tuic-server/src/h3_quinn_compat.rs
@@ -16,13 +16,13 @@ use h3::{
 	error::Code,
 	quic::{self, ConnectionErrorIncoming, StreamErrorIncoming, StreamId, WriteBuf},
 };
-use peekable::future::AsyncPeekable;
+use peekable::tokio::AsyncPeekable;
 use quinn::{AcceptBi, AcceptUni, OpenBi, OpenUni, ReadError, VarInt};
 use tokio_util::sync::ReusableBoxFuture;
 
 type BoxStreamSync<'a, T> = Pin<Box<dyn Stream<Item = T> + Sync + Send + 'a>>;
 
-pub type PeekableRecvStream = AsyncPeekable<quinn::RecvStream>;
+pub type PeekableRecvStream = AsyncPeekable<quinn::RecvStream, smallvec::SmallVec<[u8; 4]>>;
 
 pub struct PrefetchedBiRecv {
 	pub send: quinn::SendStream,
@@ -307,7 +307,7 @@ type ReadChunkFuture = ReusableBoxFuture<'static, (PeekableRecvStream, Result<Op
 impl RecvStream {
 	fn new(stream: quinn::RecvStream) -> Self {
 		let num: u64 = stream.id().into();
-		Self::new_inner(AsyncPeekable::new(stream), num)
+		Self::new_inner(AsyncPeekable::with_buffer(stream), num)
 	}
 
 	fn new_peekable(stream: PeekableRecvStream) -> Self {

--- a/tuic-server/src/h3_quinn_compat.rs
+++ b/tuic-server/src/h3_quinn_compat.rs
@@ -1,0 +1,465 @@
+use std::{
+	convert::TryInto,
+	future::Future,
+	pin::Pin,
+	sync::Arc,
+	task::{self, Poll},
+};
+
+use bytes::{Buf, Bytes};
+use futures::{
+	Stream,
+	stream::{self},
+};
+use futures_util::{StreamExt, ready};
+use h3::{
+	error::Code,
+	quic::{self, ConnectionErrorIncoming, StreamErrorIncoming, StreamId, WriteBuf},
+};
+use peekable::future::AsyncPeekable;
+use quinn::{AcceptBi, AcceptUni, OpenBi, OpenUni, ReadError, VarInt};
+use tokio_util::sync::ReusableBoxFuture;
+
+type BoxStreamSync<'a, T> = Pin<Box<dyn Stream<Item = T> + Sync + Send + 'a>>;
+
+pub type PeekableRecvStream = AsyncPeekable<quinn::RecvStream>;
+
+pub struct PrefetchedBiRecv {
+	pub send: quinn::SendStream,
+	pub recv: PeekableRecvStream,
+}
+
+pub struct Connection {
+	conn:           quinn::Connection,
+	incoming_bi:    BoxStreamSync<'static, <AcceptBi<'static> as Future>::Output>,
+	opening_bi:     Option<BoxStreamSync<'static, <OpenBi<'static> as Future>::Output>>,
+	incoming_uni:   BoxStreamSync<'static, <AcceptUni<'static> as Future>::Output>,
+	opening_uni:    Option<BoxStreamSync<'static, <OpenUni<'static> as Future>::Output>>,
+	prefetched_bi:  Option<PrefetchedBiRecv>,
+	prefetched_uni: Option<RecvStream>,
+}
+
+impl Connection {
+	pub fn new(conn: quinn::Connection) -> Self {
+		Self {
+			conn:           conn.clone(),
+			incoming_bi:    Box::pin(stream::unfold(conn.clone(), |conn| async {
+				Some((conn.accept_bi().await, conn))
+			})),
+			opening_bi:     None,
+			incoming_uni:   Box::pin(stream::unfold(conn.clone(), |conn| async {
+				Some((conn.accept_uni().await, conn))
+			})),
+			opening_uni:    None,
+			prefetched_bi:  None,
+			prefetched_uni: None,
+		}
+	}
+
+	pub fn new_with_prefetched(
+		conn: quinn::Connection,
+		prefetched_uni: Option<PeekableRecvStream>,
+		prefetched_bi: Option<PrefetchedBiRecv>,
+	) -> Self {
+		let mut this = Self::new(conn);
+		this.prefetched_uni = prefetched_uni.map(RecvStream::new_peekable);
+		this.prefetched_bi = prefetched_bi;
+		this
+	}
+}
+
+impl<B> quic::Connection<B> for Connection
+where
+	B: Buf,
+{
+	type OpenStreams = OpenStreams;
+	type RecvStream = RecvStream;
+
+	fn poll_accept_bidi(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<Self::BidiStream, ConnectionErrorIncoming>> {
+		if let Some(prefetched) = self.prefetched_bi.take() {
+			return Poll::Ready(Ok(Self::BidiStream {
+				send: Self::SendStream::new(prefetched.send),
+				recv: Self::RecvStream::new_peekable(prefetched.recv),
+			}));
+		}
+
+		let (send, recv) = ready!(self.incoming_bi.poll_next_unpin(cx))
+			.expect("self.incoming_bi never returns None")
+			.map_err(convert_connection_error)?;
+		Poll::Ready(Ok(Self::BidiStream {
+			send: Self::SendStream::new(send),
+			recv: Self::RecvStream::new(recv),
+		}))
+	}
+
+	fn poll_accept_recv(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<Self::RecvStream, ConnectionErrorIncoming>> {
+		if let Some(stream) = self.prefetched_uni.take() {
+			return Poll::Ready(Ok(stream));
+		}
+
+		let recv = ready!(self.incoming_uni.poll_next_unpin(cx))
+			.expect("self.incoming_uni never returns None")
+			.map_err(convert_connection_error)?;
+		Poll::Ready(Ok(Self::RecvStream::new(recv)))
+	}
+
+	fn opener(&self) -> Self::OpenStreams {
+		OpenStreams {
+			conn:        self.conn.clone(),
+			opening_bi:  None,
+			opening_uni: None,
+		}
+	}
+}
+
+fn convert_connection_error(err: quinn::ConnectionError) -> ConnectionErrorIncoming {
+	match err {
+		quinn::ConnectionError::ApplicationClosed(close) => ConnectionErrorIncoming::ApplicationClose {
+			error_code: close.error_code.into(),
+		},
+		quinn::ConnectionError::TimedOut => ConnectionErrorIncoming::Timeout,
+		error @ quinn::ConnectionError::VersionMismatch
+		| error @ quinn::ConnectionError::TransportError(_)
+		| error @ quinn::ConnectionError::ConnectionClosed(_)
+		| error @ quinn::ConnectionError::Reset
+		| error @ quinn::ConnectionError::LocallyClosed
+		| error @ quinn::ConnectionError::CidsExhausted => ConnectionErrorIncoming::Undefined(Arc::new(error)),
+	}
+}
+
+impl<B> quic::OpenStreams<B> for Connection
+where
+	B: Buf,
+{
+	type BidiStream = BidiStream<B>;
+	type SendStream = SendStream<B>;
+
+	fn poll_open_bidi(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<Self::BidiStream, StreamErrorIncoming>> {
+		let bi = self.opening_bi.get_or_insert_with(|| {
+			Box::pin(stream::unfold(self.conn.clone(), |conn| async {
+				Some((conn.open_bi().await, conn))
+			}))
+		});
+
+		let (send, recv) = ready!(bi.poll_next_unpin(cx))
+			.expect("BoxStream does not return None")
+			.map_err(|err| StreamErrorIncoming::ConnectionErrorIncoming {
+				connection_error: convert_connection_error(err),
+			})?;
+
+		Poll::Ready(Ok(Self::BidiStream {
+			send: Self::SendStream::new(send),
+			recv: RecvStream::new(recv),
+		}))
+	}
+
+	fn poll_open_send(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<Self::SendStream, StreamErrorIncoming>> {
+		let uni = self.opening_uni.get_or_insert_with(|| {
+			Box::pin(stream::unfold(self.conn.clone(), |conn| async {
+				Some((conn.open_uni().await, conn))
+			}))
+		});
+
+		let send = ready!(uni.poll_next_unpin(cx))
+			.expect("BoxStream does not return None")
+			.map_err(|err| StreamErrorIncoming::ConnectionErrorIncoming {
+				connection_error: convert_connection_error(err),
+			})?;
+		Poll::Ready(Ok(Self::SendStream::new(send)))
+	}
+
+	fn close(&mut self, code: Code, reason: &[u8]) {
+		self.conn
+			.close(VarInt::from_u64(code.value()).expect("error code VarInt"), reason);
+	}
+}
+
+pub struct OpenStreams {
+	conn:        quinn::Connection,
+	opening_bi:  Option<BoxStreamSync<'static, <OpenBi<'static> as Future>::Output>>,
+	opening_uni: Option<BoxStreamSync<'static, <OpenUni<'static> as Future>::Output>>,
+}
+
+impl<B> quic::OpenStreams<B> for OpenStreams
+where
+	B: Buf,
+{
+	type BidiStream = BidiStream<B>;
+	type SendStream = SendStream<B>;
+
+	fn poll_open_bidi(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<Self::BidiStream, StreamErrorIncoming>> {
+		let bi = self.opening_bi.get_or_insert_with(|| {
+			Box::pin(stream::unfold(self.conn.clone(), |conn| async {
+				Some((conn.open_bi().await, conn))
+			}))
+		});
+
+		let (send, recv) = ready!(bi.poll_next_unpin(cx))
+			.expect("BoxStream does not return None")
+			.map_err(|err| StreamErrorIncoming::ConnectionErrorIncoming {
+				connection_error: convert_connection_error(err),
+			})?;
+
+		Poll::Ready(Ok(Self::BidiStream {
+			send: Self::SendStream::new(send),
+			recv: RecvStream::new(recv),
+		}))
+	}
+
+	fn poll_open_send(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<Self::SendStream, StreamErrorIncoming>> {
+		let uni = self.opening_uni.get_or_insert_with(|| {
+			Box::pin(stream::unfold(self.conn.clone(), |conn| async {
+				Some((conn.open_uni().await, conn))
+			}))
+		});
+
+		let send = ready!(uni.poll_next_unpin(cx))
+			.expect("BoxStream does not return None")
+			.map_err(|err| StreamErrorIncoming::ConnectionErrorIncoming {
+				connection_error: convert_connection_error(err),
+			})?;
+		Poll::Ready(Ok(Self::SendStream::new(send)))
+	}
+
+	fn close(&mut self, code: Code, reason: &[u8]) {
+		self.conn
+			.close(VarInt::from_u64(code.value()).expect("error code VarInt"), reason);
+	}
+}
+
+impl Clone for OpenStreams {
+	fn clone(&self) -> Self {
+		Self {
+			conn:        self.conn.clone(),
+			opening_bi:  None,
+			opening_uni: None,
+		}
+	}
+}
+
+pub struct BidiStream<B: Buf> {
+	send: SendStream<B>,
+	recv: RecvStream,
+}
+
+impl<B: Buf> quic::BidiStream<B> for BidiStream<B> {
+	type RecvStream = RecvStream;
+	type SendStream = SendStream<B>;
+
+	fn split(self) -> (Self::SendStream, Self::RecvStream) {
+		(self.send, self.recv)
+	}
+}
+
+impl<B: Buf> quic::RecvStream for BidiStream<B> {
+	type Buf = Bytes;
+
+	fn poll_data(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<Option<Self::Buf>, StreamErrorIncoming>> {
+		self.recv.poll_data(cx)
+	}
+
+	fn stop_sending(&mut self, error_code: u64) {
+		self.recv.stop_sending(error_code)
+	}
+
+	fn recv_id(&self) -> StreamId {
+		self.recv.recv_id()
+	}
+}
+
+impl<B: Buf> quic::SendStream<B> for BidiStream<B> {
+	fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), StreamErrorIncoming>> {
+		self.send.poll_ready(cx)
+	}
+
+	fn poll_finish(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), StreamErrorIncoming>> {
+		self.send.poll_finish(cx)
+	}
+
+	fn reset(&mut self, reset_code: u64) {
+		self.send.reset(reset_code)
+	}
+
+	fn send_data<D: Into<WriteBuf<B>>>(&mut self, data: D) -> Result<(), StreamErrorIncoming> {
+		self.send.send_data(data)
+	}
+
+	fn send_id(&self) -> StreamId {
+		self.send.send_id()
+	}
+}
+
+impl<B: Buf> quic::SendStreamUnframed<B> for BidiStream<B> {
+	fn poll_send<D: Buf>(&mut self, cx: &mut task::Context<'_>, buf: &mut D) -> Poll<Result<usize, StreamErrorIncoming>> {
+		self.send.poll_send(cx, buf)
+	}
+}
+
+pub struct RecvStream {
+	stream:            Option<PeekableRecvStream>,
+	recv_id:           StreamId,
+	pending_stop_code: Option<u64>,
+	read_chunk_fut:    ReadChunkFuture,
+}
+
+type ReadChunkFuture = ReusableBoxFuture<'static, (PeekableRecvStream, Result<Option<quinn::Chunk>, quinn::ReadError>)>;
+
+impl RecvStream {
+	fn new(stream: quinn::RecvStream) -> Self {
+		let num: u64 = stream.id().into();
+		Self::new_inner(AsyncPeekable::new(stream), num)
+	}
+
+	fn new_peekable(stream: PeekableRecvStream) -> Self {
+		let num: u64 = stream.get_ref().1.id().into();
+		Self::new_inner(stream, num)
+	}
+
+	fn new_inner(stream: PeekableRecvStream, stream_id: u64) -> Self {
+		Self {
+			stream:            Some(stream),
+			recv_id:           stream_id.try_into().expect("invalid stream id"),
+			pending_stop_code: None,
+			read_chunk_fut:    ReusableBoxFuture::new(async { unreachable!() }),
+		}
+	}
+}
+
+impl quic::RecvStream for RecvStream {
+	type Buf = Bytes;
+
+	fn poll_data(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<Option<Self::Buf>, StreamErrorIncoming>> {
+		if let Some(stream) = self.stream.as_mut() {
+			let (buffered, _) = stream.get_ref();
+			if !buffered.is_empty() {
+				let buffered = Bytes::copy_from_slice(buffered);
+				stream.consume_in_place();
+				return Poll::Ready(Ok(Some(buffered)));
+			}
+		}
+
+		if let Some(mut stream) = self.stream.take() {
+			self.read_chunk_fut.set(async move {
+				let chunk = stream.get_mut().1.read_chunk(usize::MAX, true).await;
+				(stream, chunk)
+			})
+		}
+
+		let (stream, chunk) = ready!(self.read_chunk_fut.poll(cx));
+		self.stream = Some(stream);
+		if let Some(stop_code) = self.pending_stop_code.take() {
+			self.stop_sending(stop_code);
+		}
+		Poll::Ready(Ok(chunk.map_err(convert_read_error_to_stream_error)?.map(|c| c.bytes)))
+	}
+
+	fn stop_sending(&mut self, error_code: u64) {
+		if let Some(stream) = self.stream.as_mut() {
+			stream
+				.get_mut()
+				.1
+				.stop(VarInt::from_u64(error_code).expect("invalid error_code"))
+				.ok();
+		} else {
+			self.pending_stop_code = Some(error_code);
+		}
+	}
+
+	fn recv_id(&self) -> StreamId {
+		self.recv_id
+	}
+}
+
+fn convert_read_error_to_stream_error(error: ReadError) -> StreamErrorIncoming {
+	match error {
+		ReadError::Reset(var_int) => StreamErrorIncoming::StreamTerminated {
+			error_code: var_int.into_inner(),
+		},
+		ReadError::ConnectionLost(connection_error) => StreamErrorIncoming::ConnectionErrorIncoming {
+			connection_error: convert_connection_error(connection_error),
+		},
+		error @ ReadError::ClosedStream => StreamErrorIncoming::Unknown(Box::new(error)),
+		ReadError::IllegalOrderedRead => panic!("h3_quinn_compat only performs ordered reads"),
+		error @ ReadError::ZeroRttRejected => StreamErrorIncoming::Unknown(Box::new(error)),
+	}
+}
+
+fn convert_write_error_to_stream_error(error: quinn::WriteError) -> StreamErrorIncoming {
+	match error {
+		quinn::WriteError::Stopped(var_int) => StreamErrorIncoming::StreamTerminated {
+			error_code: var_int.into_inner(),
+		},
+		quinn::WriteError::ConnectionLost(connection_error) => StreamErrorIncoming::ConnectionErrorIncoming {
+			connection_error: convert_connection_error(connection_error),
+		},
+		error @ quinn::WriteError::ClosedStream | error @ quinn::WriteError::ZeroRttRejected => {
+			StreamErrorIncoming::Unknown(Box::new(error))
+		}
+	}
+}
+
+pub struct SendStream<B: Buf> {
+	stream:  quinn::SendStream,
+	writing: Option<WriteBuf<B>>,
+}
+
+impl<B: Buf> SendStream<B> {
+	fn new(stream: quinn::SendStream) -> Self {
+		Self { stream, writing: None }
+	}
+}
+
+impl<B: Buf> quic::SendStream<B> for SendStream<B> {
+	fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), StreamErrorIncoming>> {
+		if let Some(ref mut data) = self.writing {
+			while data.has_remaining() {
+				let stream = Pin::new(&mut self.stream);
+				let written = ready!(stream.poll_write(cx, data.chunk())).map_err(convert_write_error_to_stream_error)?;
+				data.advance(written);
+			}
+		}
+
+		self.writing = None;
+		Poll::Ready(Ok(()))
+	}
+
+	fn poll_finish(&mut self, _cx: &mut task::Context<'_>) -> Poll<Result<(), StreamErrorIncoming>> {
+		Poll::Ready(self.stream.finish().map_err(|e| StreamErrorIncoming::Unknown(Box::new(e))))
+	}
+
+	fn reset(&mut self, reset_code: u64) {
+		let _ = self.stream.reset(VarInt::from_u64(reset_code).unwrap_or(VarInt::MAX));
+	}
+
+	fn send_data<D: Into<WriteBuf<B>>>(&mut self, data: D) -> Result<(), StreamErrorIncoming> {
+		if self.writing.is_some() {
+			return Err(StreamErrorIncoming::ConnectionErrorIncoming {
+				connection_error: ConnectionErrorIncoming::InternalError("internal error in the http stack".to_string()),
+			});
+		}
+		self.writing = Some(data.into());
+		Ok(())
+	}
+
+	fn send_id(&self) -> StreamId {
+		let num: u64 = self.stream.id().into();
+		num.try_into().expect("invalid stream id")
+	}
+}
+
+impl<B: Buf> quic::SendStreamUnframed<B> for SendStream<B> {
+	fn poll_send<D: Buf>(&mut self, cx: &mut task::Context<'_>, buf: &mut D) -> Poll<Result<usize, StreamErrorIncoming>> {
+		if self.writing.is_some() {
+			panic!("poll_send called while send stream is not ready")
+		}
+
+		let stream = Pin::new(&mut self.stream);
+		match ready!(stream.poll_write(cx, buf.chunk())) {
+			Ok(written) => {
+				buf.advance(written);
+				Poll::Ready(Ok(written))
+			}
+			Err(err) => Poll::Ready(Err(convert_write_error_to_stream_error(err))),
+		}
+	}
+}

--- a/tuic-server/src/lib.rs
+++ b/tuic-server/src/lib.rs
@@ -17,7 +17,6 @@ pub mod compat;
 pub mod config;
 pub mod connection;
 pub mod error;
-pub mod h3_quinn_compat;
 pub mod io;
 pub mod restful;
 pub mod server;
@@ -57,3 +56,4 @@ pub async fn run(cfg: Config) -> eyre::Result<()> {
 	server.start().await;
 	Ok(())
 }
+pub mod h3_quinn_compat;

--- a/tuic-server/src/lib.rs
+++ b/tuic-server/src/lib.rs
@@ -12,10 +12,12 @@ use uuid::Uuid;
 
 pub mod acl;
 pub mod acme;
+pub mod camouflage;
 pub mod compat;
 pub mod config;
 pub mod connection;
 pub mod error;
+pub mod h3_quinn_compat;
 pub mod io;
 pub mod restful;
 pub mod server;

--- a/tuic-server/tests/config/valid_toml_config.toml
+++ b/tuic-server/tests/config/valid_toml_config.toml
@@ -10,6 +10,13 @@ auto_ssl = true
 hostname = "testhost"
 acme_email = "admin@example.com"
 
+[camouflage]
+enabled = true
+reverse_proxy_url = "https://127.0.0.1:443"
+reverse_proxy_hostname = "example.com"
+request_timeout = "15s"
+skip_backend_tls_verify = true
+
 [quic]
 initial_mtu = 1400
 min_mtu = 1300


### PR DESCRIPTION
Introduce HTTP/3 camouflage mode to handle non-TUIC ALPN traffic, enabling reverse proxy functionality to a configurable backend. Includes configuration options for timeout, hostname override, and skipping TLS verification.

I tested on my server, tuic functionality and HTTP3 server worked.
docker run -it --rm alpine/curl-http3 curl --http3-only https://redacted.com -v
