### PR TITLE
refactor: tracing spans + log config section

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2995,6 +2995,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3384,6 +3390,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3416,6 +3435,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3425,6 +3454,8 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -3432,6 +3463,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -3583,6 +3615,7 @@ dependencies = [
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "tuic-core",
  "uuid",

--- a/tuic-server/Cargo.toml
+++ b/tuic-server/Cargo.toml
@@ -70,8 +70,9 @@ pest_derive = "2"
 # Logging
 time = { version = "0.3", features = ["macros", "local-offset"] }
 humantime = { version = "2", default-features = false }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["tracing-log", "std", "local-time","fmt", "ansi"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["tracing-log", "std", "local-time","fmt", "ansi", "json"] }
 tracing = "0.1"
+tracing-appender = "0.2"
 
 # Error handling
 thiserror = { version = "2", default-features = false }

--- a/tuic-server/src/camouflage.rs
+++ b/tuic-server/src/camouflage.rs
@@ -29,9 +29,9 @@ pub async fn handle(
 	let (backend, backend_host_override, client) = build_backend_route(camouflage)?;
 
 	info!(
-		"[{id:#010x}] [{addr}] [camouflage] HTTP/3 camouflage enabled, reverse proxy target={target}, backend_host={host:?}",
 		id = conn.stable_id() as u32,
-		addr = conn.remote_address(),
+		addr = %conn.remote_address(),
+		"HTTP/3 camouflage enabled, reverse proxy target={target}, backend_host={host:?}",
 		target = backend,
 		host = backend_host_override
 	);

--- a/tuic-server/src/config.rs
+++ b/tuic-server/src/config.rs
@@ -90,6 +90,10 @@ pub struct Config {
 	#[educe(Default = "")]
 	pub data_dir: PathBuf,
 
+	/// Logging configuration.
+	#[serde(default)]
+	pub log: LogConfig,
+
 	#[educe(Default = None)]
 	pub restful: Option<RestfulConfig>,
 
@@ -495,6 +499,44 @@ pub enum LogLevel {
 	Warn,
 	Error,
 	Off,
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum LogFormat {
+	#[default]
+	Text,
+	Json,
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum LogRotation {
+	#[default]
+	Never,
+	Hourly,
+	Daily,
+}
+
+/// Logging settings.
+#[derive(Debug, Clone, Deserialize, Serialize, Educe)]
+#[serde(deny_unknown_fields)]
+#[educe(Default)]
+pub struct LogConfig {
+	/// Log output format for stdout and log_file.
+	pub format: LogFormat,
+
+	/// Use compact log format (single-line, less verbose). Only applies to
+	/// `text` format.
+	#[educe(Default = true)]
+	pub compact: bool,
+
+	/// Optional log file path. When set, logs are also written to this file
+	/// with the configured `log_rotation` policy.
+	pub log_file: Option<PathBuf>,
+
+	/// Rotation policy for `log_file`.
+	pub log_rotation: LogRotation,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, serde::Serialize)]

--- a/tuic-server/src/connection/handle_stream.rs
+++ b/tuic-server/src/connection/handle_stream.rs
@@ -12,12 +12,7 @@ use crate::{error::Error, utils::UdpRelayMode};
 
 impl Connection {
 	pub async fn handle_uni_stream<R: StreamRx>(self, recv: R, reg: Register) {
-		debug!(
-			"[{id:#010x}] [{addr}] [{user}] incoming unidirectional stream",
-			id = self.id(),
-			addr = self.inner.remote_address(),
-			user = self.auth,
-		);
+		debug!("incoming unidirectional stream");
 
 		self.maybe_expand_uni_stream_limit();
 
@@ -50,12 +45,7 @@ impl Connection {
 			Ok(Task::Dissociate(assoc_id)) => self.handle_dissociate(assoc_id).await,
 			Ok(_) => unreachable!(),
 			Err(err) => {
-				warn!(
-					"[{id:#010x}] [{addr}] [{user}] handling incoming unidirectional stream error: {err}",
-					id = self.id(),
-					addr = self.inner.remote_address(),
-					user = self.auth,
-				);
+				warn!("handling incoming unidirectional stream error: {err}");
 				self.close();
 			}
 		}
@@ -63,12 +53,7 @@ impl Connection {
 	}
 
 	pub async fn handle_bi_stream<S: StreamTx, R: StreamRx>(self, (send, recv): (S, R), reg: Register) {
-		debug!(
-			"[{id:#010x}] [{addr}] [{user}] incoming bidirectional stream",
-			id = self.id(),
-			addr = self.inner.remote_address(),
-			user = self.auth,
-		);
+		debug!("incoming bidirectional stream");
 
 		self.maybe_expand_bi_stream_limit();
 
@@ -91,12 +76,7 @@ impl Connection {
 			Ok(Task::Connect(conn)) => self.handle_connect(conn).await,
 			Ok(_) => unreachable!(),
 			Err(err) => {
-				warn!(
-					"[{id:#010x}] [{addr}] [{user}] handling incoming bidirectional stream error: {err}",
-					id = self.id(),
-					addr = self.inner.remote_address(),
-					user = self.auth,
-				);
+				warn!("handling incoming bidirectional stream error: {err}");
 				self.close();
 			}
 		}
@@ -114,8 +94,7 @@ impl Connection {
 				Ordering::Acquire,
 			) {
 			debug!(
-				"[{id:#010x}] reached max concurrent uni_streams, setting bigger limitation={num}",
-				id = self.id(),
+				"reached max concurrent uni_streams, setting bigger limitation={num}",
 				num = current_max * 2
 			);
 			self.inner.set_max_concurrent_uni_streams(VarInt::from(current_max * 2));
@@ -133,8 +112,7 @@ impl Connection {
 				Ordering::Acquire,
 			) {
 			debug!(
-				"[{id:#010x}] reached max concurrent bi_streams, setting bigger limitation={num}",
-				id = self.id(),
+				"reached max concurrent bi_streams, setting bigger limitation={num}",
 				num = current_max * 2
 			);
 			self.inner.set_max_concurrent_bi_streams(VarInt::from(current_max * 2));
@@ -142,12 +120,7 @@ impl Connection {
 	}
 
 	pub async fn handle_datagram(self, dg: Bytes) {
-		debug!(
-			"[{id:#010x}] [{addr}] [{user}] incoming datagram",
-			id = self.id(),
-			addr = self.inner.remote_address(),
-			user = self.auth,
-		);
+		debug!("incoming datagram");
 
 		let pre_process = async {
 			let task = self.model.accept_datagram(dg)?;
@@ -171,12 +144,7 @@ impl Connection {
 			Ok(Task::Heartbeat) => self.handle_heartbeat().await,
 			Ok(_) => unreachable!(),
 			Err(err) => {
-				warn!(
-					"[{id:#010x}] [{addr}] [{user}] handling incoming datagram error: {err}",
-					id = self.id(),
-					addr = self.inner.remote_address(),
-					user = self.auth,
-				);
+				warn!("handling incoming datagram error: {err}");
 				self.close();
 			}
 		}

--- a/tuic-server/src/connection/handle_task.rs
+++ b/tuic-server/src/connection/handle_task.rs
@@ -177,24 +177,13 @@ impl Connection {
 	}
 
 	pub async fn handle_authenticate(&self, auth: Authenticate) {
-		info!(
-			"[{id:#010x}] [{addr}] [{user}] [AUTH] {auth_uuid}",
-			id = self.id(),
-			addr = self.inner.remote_address(),
-			user = self.auth,
-			auth_uuid = auth.uuid(),
-		);
+		info!("[AUTH] {}", auth.uuid());
 	}
 
 	pub async fn handle_connect<S: StreamTx, R: StreamRx>(&self, mut conn: Connect<S, R>) {
 		let target_addr = conn.addr().to_string();
 
-		info!(
-			"[{id:#010x}] [{addr}] [{user}] [TCP] {target_addr} ",
-			id = self.id(),
-			addr = self.inner.remote_address(),
-			user = self.auth,
-		);
+		info!("[TCP] {target_addr} ");
 
 		let process = async {
 			// First resolve using default outbound to get candidate IPs
@@ -210,12 +199,7 @@ impl Connection {
 			let (outbound_name, hijack, drop) = self.decide_acl_for_addrs(&initial_addrs, port, true, domain).await;
 
 			if drop {
-				warn!(
-					"[{id:#010x}] [{addr}] [{user}] [TCP] {target_addr} blocked by ACL",
-					id = self.id(),
-					addr = self.inner.remote_address(),
-					user = self.auth,
-				);
+				warn!("[TCP] {target_addr} blocked by ACL");
 				_ = conn.reset(ERROR_CODE);
 				return Ok(());
 			}
@@ -255,12 +239,7 @@ impl Connection {
 
 		match process.await {
 			Ok(()) => {}
-			Err(err) => warn!(
-				"[{id:#010x}] [{addr}] [{user}] [TCP] {target_addr}: {err}",
-				id = self.id(),
-				addr = self.inner.remote_address(),
-				user = self.auth,
-			),
+			Err(err) => warn!("[TCP] {target_addr}: {err}"),
 		}
 	}
 
@@ -326,12 +305,8 @@ impl Connection {
 		let frag_total = pkt.frag_total();
 
 		info!(
-			"[{id:#010x}] [{addr}] [{user}] [UDP-OUT] [{assoc_id:#06x}] [from-{mode}] [{pkt_id:#06x}] fragment \
-			 {frag_id}/{frag_total}",
-			id = self.id(),
-			addr = self.inner.remote_address(),
-			user = self.auth,
-			frag_id = frag_id + 1,
+			"[UDP-OUT] [{assoc_id:#06x}] [from-{mode}] [{pkt_id:#06x}] fragment {frag_id}/{frag_total}",
+			frag_id = frag_id + 1
 		);
 
 		self.udp_relay_mode.store(Some(mode).into());
@@ -341,11 +316,7 @@ impl Connection {
 			Ok(Some(res)) => res,
 			Err(err) => {
 				warn!(
-					"[{id:#010x}] [{addr}] [{user}] [UDP-OUT] [{assoc_id:#06x}] [from-{mode}] [{pkt_id:#06x}] fragment \
-					 {frag_id}/{frag_total}: {err}",
-					id = self.id(),
-					addr = self.inner.remote_address(),
-					user = self.auth,
+					"[UDP-OUT] [{assoc_id:#06x}] [from-{mode}] [{pkt_id:#06x}] fragment {frag_id}/{frag_total}: {err}",
 					frag_id = frag_id + 1,
 				);
 				return;
@@ -354,11 +325,8 @@ impl Connection {
 
 		let process = async {
 			info!(
-				"[{id:#010x}] [{addr}] [{user}] [UDP-OUT] [{assoc_id:#06x}] [from-{mode}] [{pkt_id:#06x}] to {src_addr}",
-				id = self.id(),
-				addr = self.inner.remote_address(),
-				user = self.auth,
-				src_addr = addr,
+				"[UDP-OUT] [{assoc_id:#06x}] [from-{mode}] [{pkt_id:#06x}] to {src_addr}",
+				src_addr = addr
 			);
 
 			let guard = self.udp_sessions.read().await;
@@ -391,12 +359,8 @@ impl Connection {
 			if should_drop {
 				// Silently drop the packet as per ACL
 				warn!(
-					"[{id:#010x}] [{addr}] [{user}] [UDP-OUT] [{assoc_id:#06x}] [from-{mode}] [{pkt_id:#06x}] to {src_addr} \
-					 blocked by ACL",
-					id = self.id(),
-					addr = self.inner.remote_address(),
-					user = self.auth,
-					src_addr = addr,
+					"[UDP-OUT] [{assoc_id:#06x}] [from-{mode}] [{pkt_id:#06x}] to {src_addr} blocked by ACL",
+					src_addr = addr
 				);
 				return Ok(());
 			}
@@ -409,34 +373,21 @@ impl Connection {
 				let allow_udp = outbound.allow_udp.unwrap_or(false);
 				if !allow_udp {
 					warn!(
-						"[{id:#010x}] [{addr}] [{user}] [UDP-OUT-SOCKS5] [{assoc_id:#06x}] [from-{mode}] [{pkt_id:#06x}] to \
-						 {src_addr} blocked by ACL",
-						id = self.id(),
-						addr = self.inner.remote_address(),
-						user = self.auth,
-						src_addr = addr,
+						"[UDP-OUT-SOCKS5] [{assoc_id:#06x}] [from-{mode}] [{pkt_id:#06x}] to {src_addr} blocked by ACL",
+						src_addr = addr
 					);
 					// Silently drop UDP to avoid leaking QUIC/HTTP3 when SOCKS5 is requested
 					return Ok(());
 				} else {
 					// We don't support UDP via SOCKS5 yet; fall back to direct
 					info!(
-						"[{id:#010x}] [{addr}] [{user}] [UDP-OUT] [{assoc_id:#06x}] outbound '{outbound_name}' allows UDP but \
-						 UDP via SOCKS5 not supported; using direct as you configured",
-						id = self.id(),
-						addr = self.inner.remote_address(),
-						user = self.auth,
+						"[UDP-OUT] [{assoc_id:#06x}] outbound '{outbound_name}' allows UDP but UDP via SOCKS5 not supported; \
+						 using direct as you configured"
 					);
 				}
 			} else if !outbound.kind.eq_ignore_ascii_case("direct") {
 				// Outbound other than direct is not supported for UDP yet; proceed as direct
-				warn!(
-					"[{id:#010x}] [{addr}] [{user}] [UDP-OUT] [{assoc_id:#06x}] outbound '{outbound_name}' not supported; \
-					 using direct",
-					id = self.id(),
-					addr = self.inner.remote_address(),
-					user = self.auth,
-				);
+				warn!("[UDP-OUT] [{assoc_id:#06x}] outbound '{outbound_name}' not supported; using direct");
 			}
 
 			let socket_addr = if let Some(h) = hijack {
@@ -457,22 +408,14 @@ impl Connection {
 
 		if let Err(err) = process.await {
 			warn!(
-				"[{id:#010x}] [{addr}] [{user}] [UDP-OUT] [{assoc_id:#06x}] [from-{mode}] [{pkt_id:#06x}] to {src_addr}: {err}",
-				id = self.id(),
-				addr = self.inner.remote_address(),
-				user = self.auth,
-				src_addr = addr,
+				"[UDP-OUT] [{assoc_id:#06x}] [from-{mode}] [{pkt_id:#06x}] to {src_addr}: {err}",
+				src_addr = addr
 			);
 		}
 	}
 
 	pub async fn handle_dissociate(&self, assoc_id: u16) {
-		info!(
-			"[{id:#010x}] [{addr}] [{user}] [UDP-DROP] [{assoc_id:#06x}]",
-			id = self.id(),
-			addr = self.inner.remote_address(),
-			user = self.auth,
-		);
+		info!("[UDP-DROP] [{assoc_id:#06x}]");
 
 		if let Some(session) = self.udp_sessions.write().await.remove(&assoc_id)
 			&& let Some(session) = session.upgrade()
@@ -482,24 +425,16 @@ impl Connection {
 	}
 
 	pub async fn handle_heartbeat(&self) {
-		info!(
-			"[{id:#010x}] [{addr}] [{user}] [HB]",
-			id = self.id(),
-			addr = self.inner.remote_address(),
-			user = self.auth,
-		);
+		info!("[HB]");
 	}
 
 	pub async fn relay_packet(self, pkt: Bytes, addr: Address, assoc_id: u16) -> eyre::Result<()> {
 		let addr_display = addr.to_string();
 
 		info!(
-			"[{id:#010x}] [{addr}] [{user}] [UDP-IN] [{assoc_id:#06x}] [to-{mode}] from {src_addr}",
-			id = self.id(),
-			addr = self.inner.remote_address(),
-			user = self.auth,
+			"[UDP-IN] [{assoc_id:#06x}] [to-{mode}] from {src_addr}",
 			mode = self.udp_relay_mode.load().unwrap(),
-			src_addr = addr_display,
+			src_addr = addr_display
 		);
 
 		restful::traffic_rx(&self.ctx, &self.auth.get().ok_or_eyre("Unreachable")?, pkt.len());
@@ -511,12 +446,9 @@ impl Connection {
 
 		if let Err(err) = res {
 			warn!(
-				"[{id:#010x}] [{addr}] [{user}] [UDP-IN] [{assoc_id:#06x}] [to-{mode}] from {src_addr}: {err}",
-				id = self.id(),
-				addr = self.inner.remote_address(),
-				user = self.auth,
+				"[UDP-IN] [{assoc_id:#06x}] [to-{mode}] from {src_addr}: {err}",
 				mode = self.udp_relay_mode.load().unwrap(),
-				src_addr = addr_display,
+				src_addr = addr_display
 			);
 		}
 		Ok(())

--- a/tuic-server/src/connection/mod.rs
+++ b/tuic-server/src/connection/mod.rs
@@ -11,7 +11,7 @@ use quinn::{Connecting, Connection as QuinnConnection, VarInt};
 use register_count::Counter;
 use smallvec::SmallVec;
 use tokio::{sync::RwLock as AsyncRwLock, time};
-use tracing::{debug, info, warn};
+use tracing::{Instrument, Span, debug, info, info_span, warn};
 use tuic_core::quinn::{Authenticate, Connection as Model, side};
 
 use self::{authenticated::Authenticated, udp_session::UdpSession};
@@ -69,7 +69,7 @@ pub struct Connection {
 
 impl Connection {
 	pub async fn handle(ctx: Arc<AppContext>, conn: Connecting) {
-		let addr = conn.remote_address();
+		let peer_addr = conn.remote_address();
 
 		let init = async {
 			let conn = if ctx.cfg.zero_rtt_handshake {
@@ -86,68 +86,85 @@ impl Connection {
 
 		match init.await {
 			Ok(conn) => {
+				let conn_span = info_span!(
+					"conn",
+					id = conn.id(),
+					addr = %conn.inner.remote_address(),
+					user = tracing::field::Empty,
+				);
+				let _guard = conn_span.enter();
+				let conn_span = conn_span.clone();
+
 				if ctx.cfg.camouflage.as_ref().is_some_and(|cfg| cfg.enabled) {
 					match conn.classify_h3_dispatch().await {
 						Ok(H3Dispatch::Camouflage {
 							prefetched_uni,
 							prefetched_bi,
 						}) => {
+							drop(_guard);
 							if let Err(err) =
 								camouflage::handle(ctx.clone(), conn.inner.clone(), prefetched_uni, prefetched_bi).await
 							{
-								warn!("[{id:#010x}] [{addr}] [camouflage] {err}", id = conn.id(), addr = addr);
+								warn!(parent: &conn_span, "camouflage: {err}");
 							}
 							return;
 						}
 						Ok(H3Dispatch::Tuic(first_event)) => {
-							info!(
-								"[{id:#010x}] [{addr}] [{user}] connection established",
-								id = conn.id(),
-								user = conn.auth,
+							info!("connection established");
+							tokio::spawn(
+								conn.clone()
+									.timeout_authenticate(ctx.cfg.auth_timeout)
+									.instrument(conn_span.clone()),
 							);
-							tokio::spawn(conn.clone().timeout_authenticate(ctx.cfg.auth_timeout));
-							tokio::spawn(conn.clone().collect_garbage());
+							tokio::spawn(conn.clone().collect_garbage().instrument(conn_span.clone()));
 							if let Some(first_event) = first_event {
+								let span = conn_span.clone();
 								match first_event {
 									PrefetchedFirstEventTuic::Uni(recv) => {
-										tokio::spawn(conn.clone().handle_uni_stream(recv, conn.remote_uni_stream_cnt.reg()));
+										tokio::spawn(
+											conn.clone()
+												.handle_uni_stream(recv, conn.remote_uni_stream_cnt.reg())
+												.instrument(span),
+										);
 									}
 									PrefetchedFirstEventTuic::Bi { send, recv } => {
 										tokio::spawn(
-											conn.clone().handle_bi_stream((send, recv), conn.remote_bi_stream_cnt.reg()),
+											conn.clone()
+												.handle_bi_stream((send, recv), conn.remote_bi_stream_cnt.reg())
+												.instrument(span),
 										);
 									}
 									PrefetchedFirstEventTuic::Datagram(dg) => {
-										tokio::spawn(conn.clone().handle_datagram(dg));
+										tokio::spawn(conn.clone().handle_datagram(dg).instrument(span));
 									}
 								}
 							}
 
-							conn.run_tuic_event_loop().await;
+							conn.run_tuic_event_loop().instrument(conn_span).await;
 							return;
 						}
 						Err(err) => {
-							warn!("[{id:#010x}] [{addr}] [classifier] {err}", id = conn.id(), addr = addr);
+							warn!("classifier: {err}");
 							conn.close();
 							return;
 						}
 					}
 				}
 
-				info!(
-					"[{id:#010x}] [{addr}] [{user}] connection established",
-					id = conn.id(),
-					user = conn.auth,
+				info!("connection established");
+				tokio::spawn(
+					conn.clone()
+						.timeout_authenticate(ctx.cfg.auth_timeout)
+						.instrument(conn_span.clone()),
 				);
-				tokio::spawn(conn.clone().timeout_authenticate(ctx.cfg.auth_timeout));
-				tokio::spawn(conn.clone().collect_garbage());
-				conn.run_tuic_event_loop().await;
+				tokio::spawn(conn.clone().collect_garbage().instrument(conn_span.clone()));
+				conn.run_tuic_event_loop().instrument(conn_span).await;
 			}
 			Err(err) if err.is_trivial() => {
-				debug!("[{id:#010x}] [{addr}] [unauthenticated] {err}", id = u32::MAX,);
+				debug!(id = u32::MAX, addr = %peer_addr, "{err}");
 			}
 			Err(err) => {
-				warn!("[{id:#010x}] [{addr}] [unauthenticated] {err}", id = u32::MAX,)
+				warn!(id = u32::MAX, addr = %peer_addr, "{err}")
 			}
 		}
 	}
@@ -178,6 +195,7 @@ impl Connection {
 			.is_some_and(|password| auth.validate(password))
 		{
 			self.auth.set(auth.uuid()).await;
+			Span::current().record("user", auth.uuid().to_string());
 			Ok(())
 		} else {
 			Err(Error::AuthFailed(auth.uuid()))
@@ -192,11 +210,7 @@ impl Connection {
 				restful::client_connect(&self.ctx, &uuid, self.inner).await;
 			}
 			None => {
-				warn!(
-					"[{id:#010x}] [{addr}] [unauthenticated] [authenticate] timeout",
-					id = self.id(),
-					addr = self.inner.remote_address(),
-				);
+				warn!("[authenticate] timeout");
 				self.close();
 			}
 		}
@@ -213,12 +227,7 @@ impl Connection {
 				break;
 			}
 
-			debug!(
-				"[{id:#010x}] [{addr}] [{user}] packet fragment garbage collecting event",
-				id = self.id(),
-				addr = self.inner.remote_address(),
-				user = self.auth,
-			);
+			debug!("packet fragment garbage collecting event");
 			self.model.collect_garbage(self.ctx.cfg.gc_lifetime);
 		}
 	}
@@ -311,6 +320,7 @@ impl Connection {
 	}
 
 	async fn run_tuic_event_loop(&self) {
+		let span = Span::current();
 		loop {
 			if self.is_closed() {
 				break;
@@ -319,11 +329,11 @@ impl Connection {
 			let handle_incoming = async {
 				tokio::select! {
 					res = self.inner.accept_uni() =>
-						tokio::spawn(self.clone().handle_uni_stream(res?, self.remote_uni_stream_cnt.reg())),
+						tokio::spawn(self.clone().handle_uni_stream(res?, self.remote_uni_stream_cnt.reg()).instrument(span.clone())),
 					res = self.inner.accept_bi() =>
-						tokio::spawn(self.clone().handle_bi_stream(res?, self.remote_bi_stream_cnt.reg())),
+						tokio::spawn(self.clone().handle_bi_stream(res?, self.remote_bi_stream_cnt.reg()).instrument(span.clone())),
 					res = self.inner.read_datagram() =>
-						tokio::spawn(self.clone().handle_datagram(res?)),
+						tokio::spawn(self.clone().handle_datagram(res?).instrument(span.clone())),
 				};
 
 				Ok::<_, Error>(())
@@ -332,19 +342,9 @@ impl Connection {
 			match handle_incoming.await {
 				Ok(()) => {}
 				Err(err) if err.is_trivial() => {
-					debug!(
-						"[{id:#010x}] [{addr}] [{user}] {err}",
-						id = self.id(),
-						addr = self.inner.remote_address(),
-						user = self.auth,
-					);
+					debug!("{err}");
 				}
-				Err(err) => warn!(
-					"[{id:#010x}] [{addr}] [{user}] connection error: {err}",
-					id = self.id(),
-					addr = self.inner.remote_address(),
-					user = self.auth,
-				),
+				Err(err) => warn!("connection error: {err}"),
 			}
 		}
 	}

--- a/tuic-server/src/connection/udp_session.rs
+++ b/tuic-server/src/connection/udp_session.rs
@@ -10,7 +10,7 @@ use tokio::{
 	net::UdpSocket,
 	sync::{RwLock as AsyncRwLock, oneshot},
 };
-use tracing::warn;
+use tracing::{Instrument, Span, warn};
 use tuic_core::Address;
 
 use super::Connection;
@@ -77,6 +77,7 @@ impl UdpSession {
 
 		let session_listening = session.clone();
 		// UdpSession's real owner.
+		let listen_span = Span::current();
 		let listen = async move {
 			let mut rx = rx;
 			let mut timeout = tokio::time::interval(ctx.cfg.stream_timeout);
@@ -89,12 +90,7 @@ impl UdpSession {
 					// Avoid client didn't send `UDP-DROP` properly
 					_ = timeout.tick() => {
 						session_listening.close().await;
-						warn!(
-							"[{id:#010x}] [{addr}] [{user}] [packet] [{assoc_id:#06x}] UDP session timeout",
-							id = session_listening.conn.id(),
-							addr = session_listening.conn.inner.remote_address(),
-							user = session_listening.conn.auth,
-						);
+						warn!("[packet] [{assoc_id:#06x}] UDP session timeout", assoc_id = session_listening.assoc_id);
 						continue;
 					},
 					// `UDP-DROP`
@@ -105,10 +101,8 @@ impl UdpSession {
 					Ok(v) => v,
 					Err(err) => {
 						warn!(
-							"[{id:#010x}] [{addr}] [{user}] [packet] [{assoc_id:#06x}] outbound listening error: {err}",
-							id = session_listening.conn.id(),
-							addr = session_listening.conn.inner.remote_address(),
-							user = session_listening.conn.auth,
+							"[packet] [{assoc_id:#06x}] outbound listening error: {err}",
+							assoc_id = session_listening.assoc_id
 						);
 						continue;
 					}
@@ -125,7 +119,7 @@ impl UdpSession {
 			session_listening.conn.udp_sessions.write().await.remove(&assoc_id);
 		};
 
-		tokio::spawn(listen);
+		tokio::spawn(listen.instrument(listen_span));
 		Ok(Arc::downgrade(&session))
 	}
 

--- a/tuic-server/src/connection/udp_session.rs
+++ b/tuic-server/src/connection/udp_session.rs
@@ -79,6 +79,7 @@ impl UdpSession {
 		// UdpSession's real owner.
 		let listen_span = Span::current();
 		let listen = async move {
+			let span = Span::current();
 			let mut rx = rx;
 			let mut timeout = tokio::time::interval(ctx.cfg.stream_timeout);
 			timeout.reset();
@@ -113,7 +114,8 @@ impl UdpSession {
 						.conn
 						.clone()
 						.relay_packet(pkt, Address::SocketAddress(addr), session_listening.assoc_id)
-						.log_err(),
+						.log_err()
+						.instrument(span.clone()),
 				);
 			}
 			session_listening.conn.udp_sessions.write().await.remove(&assoc_id);

--- a/tuic-server/src/lib.rs
+++ b/tuic-server/src/lib.rs
@@ -18,6 +18,7 @@ pub mod config;
 pub mod connection;
 pub mod error;
 pub mod io;
+pub mod log;
 pub mod restful;
 pub mod server;
 pub mod tls;

--- a/tuic-server/src/log.rs
+++ b/tuic-server/src/log.rs
@@ -1,0 +1,125 @@
+use std::io;
+
+use eyre::Context as _;
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::{Layer, fmt::time::LocalTime, layer::SubscriberExt as _, util::SubscriberInitExt as _};
+
+use crate::config::{Config, LogConfig, LogFormat, LogRotation};
+
+/// RAII guards that keep background tasks alive for the program's lifetime.
+pub struct LogGuards {
+	_file_guard: Option<tracing_appender::non_blocking::WorkerGuard>,
+}
+
+/// Initialise tracing from [`Config`].
+pub fn init(config: &Config) -> eyre::Result<LogGuards> {
+	let filter = tracing_subscriber::filter::Targets::new()
+		.with_targets(vec![
+			("tuic", config.log_level),
+			("tuic_quinn", config.log_level),
+			("tuic_server", config.log_level),
+		])
+		.with_default(LevelFilter::INFO);
+
+	let (file_writer, file_guard) = build_file_writer(&config.log)?;
+	let writer = move || -> Box<dyn io::Write + Send> {
+		match file_writer.as_ref() {
+			Some(fw) => Box::new(TeeWriter {
+				a: io::stdout(),
+				b: fw.clone(),
+			}),
+			None => Box::new(io::stdout()),
+		}
+	};
+
+	let timer = LocalTime::new(time::macros::format_description!(
+		"[year repr:last_two]-[month]-[day] [hour]:[minute]:[second]"
+	));
+
+	let fmt_layer: BoxedLayer<tracing_subscriber::Registry> = match config.log.format {
+		LogFormat::Text if config.log.compact => tracing_subscriber::fmt::layer()
+			.with_target(false)
+			.with_thread_ids(false)
+			.with_timer(timer)
+			.with_writer(writer)
+			.compact()
+			.with_filter(filter)
+			.boxed(),
+		LogFormat::Text => tracing_subscriber::fmt::layer()
+			.with_target(false)
+			.with_thread_ids(false)
+			.with_timer(timer)
+			.with_writer(writer)
+			.with_filter(filter)
+			.boxed(),
+		LogFormat::Json => tracing_subscriber::fmt::layer()
+			.with_target(true)
+			.with_timer(timer)
+			.with_writer(writer)
+			.json()
+			.with_current_span(true)
+			.with_span_list(false)
+			.with_filter(filter)
+			.boxed(),
+	};
+
+	tracing_subscriber::registry()
+		.with(fmt_layer)
+		.try_init()
+		.context("installing tracing subscriber")?;
+
+	Ok(LogGuards { _file_guard: file_guard })
+}
+
+/// Build a cloneable, non-blocking file writer if `log_file` is set.
+fn build_file_writer(
+	t: &LogConfig,
+) -> eyre::Result<(
+	Option<tracing_appender::non_blocking::NonBlocking>,
+	Option<tracing_appender::non_blocking::WorkerGuard>,
+)> {
+	let Some(path) = t.log_file.as_ref() else {
+		return Ok((None, None));
+	};
+
+	let dir = path.parent().filter(|p| !p.as_os_str().is_empty()).map(|p| p.to_owned());
+	let file_name = path
+		.file_name()
+		.ok_or_else(|| eyre::eyre!("log.log_file must include a file name: {path:?}"))?
+		.to_owned();
+	let dir = dir.unwrap_or_else(|| std::path::PathBuf::from("."));
+
+	if let Err(e) = std::fs::create_dir_all(&dir) {
+		return Err(eyre::eyre!("creating log directory {dir:?}: {e}"));
+	}
+
+	let appender = match t.log_rotation {
+		LogRotation::Never => tracing_appender::rolling::never(&dir, &file_name),
+		LogRotation::Hourly => tracing_appender::rolling::hourly(&dir, &file_name),
+		LogRotation::Daily => tracing_appender::rolling::daily(&dir, &file_name),
+	};
+	let (nb, guard) = tracing_appender::non_blocking(appender);
+	Ok((Some(nb), Some(guard)))
+}
+
+/// Tee writer: writes to two sinks, returning the first error.
+struct TeeWriter<A: io::Write, B: io::Write> {
+	a: A,
+	b: B,
+}
+
+impl<A: io::Write, B: io::Write> io::Write for TeeWriter<A, B> {
+	fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+		let n = self.a.write(buf)?;
+		let _ = self.b.write_all(&buf[..n]);
+		Ok(n)
+	}
+
+	fn flush(&mut self) -> io::Result<()> {
+		let r = self.a.flush();
+		let _ = self.b.flush();
+		r
+	}
+}
+
+type BoxedLayer<S> = Box<dyn Layer<S> + Send + Sync>;

--- a/tuic-server/src/main.rs
+++ b/tuic-server/src/main.rs
@@ -3,9 +3,10 @@ use std::process;
 use clap::Parser;
 #[cfg(feature = "jemallocator")]
 use tikv_jemallocator::Jemalloc;
-use tracing::level_filters::LevelFilter;
-use tracing_subscriber::{fmt::time::LocalTime, layer::SubscriberExt, util::SubscriberInitExt};
-use tuic_server::config::{Cli, Control, EnvState, ResolvedRuntime, parse_config};
+use tuic_server::{
+	config::{Cli, Control, EnvState, ResolvedRuntime, parse_config},
+	log,
+};
 
 #[cfg(feature = "jemallocator")]
 #[global_allocator]
@@ -42,26 +43,7 @@ fn main() -> eyre::Result<()> {
 			return Err(err);
 		}
 	};
-	let filter = tracing_subscriber::filter::Targets::new()
-		.with_targets(vec![
-			("tuic", cfg.log_level),
-			("tuic_quinn", cfg.log_level),
-			("tuic_server", cfg.log_level),
-		])
-		.with_default(LevelFilter::INFO);
-	let registry = tracing_subscriber::registry();
-	registry
-		.with(filter)
-		.with(
-			tracing_subscriber::fmt::layer()
-				.with_target(false)
-				.with_thread_ids(false)
-				.with_timer(LocalTime::new(time::macros::format_description!(
-					"[year repr:last_two]-[month]-[day] [hour]:[minute]:[second]"
-				)))
-				.compact(),
-		)
-		.try_init()?;
+	let _log_guards = log::init(&cfg)?;
 
 	let mut builder = match cfg.tokio_runtime.resolve() {
 		ResolvedRuntime::MultiThread => tokio::runtime::Builder::new_multi_thread(),

--- a/tuic-server/src/main.rs
+++ b/tuic-server/src/main.rs
@@ -54,10 +54,12 @@ fn main() -> eyre::Result<()> {
 		.with(filter)
 		.with(
 			tracing_subscriber::fmt::layer()
-				.with_target(true)
+				.with_target(false)
+				.with_thread_ids(false)
 				.with_timer(LocalTime::new(time::macros::format_description!(
 					"[year repr:last_two]-[month]-[day] [hour]:[minute]:[second]"
-				))),
+				)))
+				.compact(),
 		)
 		.try_init()?;
 


### PR DESCRIPTION

## Changes

### 1. Replace manual log prefixes with tracing spans
- Add per-connection `info_span!` with `id`, `addr`, `user` fields
- Instrument all spawned tasks with `.instrument()` for span propagation
- Record `user` on span after authentication
- Remove all `[{id:#010x}] [{addr}] [{user}]` manual prefixes

### 2. Add log config section (naive-rs style)
- `LogConfig` with `format` (text/json), `compact`, `log_file`, `log_rotation`
- New `log::init()` module for tracing initialization
- `tracing-appender` for log file rotation

### Config example
```toml
[log]
format = "text"
compact = true
log_file = "/var/log/tuic.log"
log_rotation = "daily"
```
