### PR TITLE
perf: replace management-path locks with moka concurrent cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3510,6 +3510,7 @@ dependencies = [
  "humantime",
  "humantime-serde",
  "json5 1.3.1",
+ "moka",
  "num_cpus",
  "once_cell",
  "quinn 0.12.0",

--- a/tuic-client/Cargo.toml
+++ b/tuic-client/Cargo.toml
@@ -18,6 +18,7 @@ aws-lc-rs = ["tuic-core/aws-lc-rs", "dep:aws-lc-rs", "rustls/aws-lc-rs", "quinn/
 jemallocator = ["tikv-jemallocator"]
 
 [dependencies]
+moka = { version = "0.12", features = ["future"] }
 num_cpus = "1"
 bytes = { version = "1", default-features = false, features = ["std"] }
 

--- a/tuic-client/src/connection/handle_task.rs
+++ b/tuic-client/src/connection/handle_task.rs
@@ -126,7 +126,7 @@ impl Connection {
 					Address::SocketAddress(addr) => Socks5Address::SocketAddress(addr),
 				};
 
-				let session = self.socks5_udp_sessions.read().await.get(&assoc_id).cloned();
+				let session = self.socks5_udp_sessions.get(&assoc_id).await;
 
 				info!("[relay] [packet] [{assoc_id:#06x}] Checking session map.");
 
@@ -138,7 +138,7 @@ impl Connection {
 						);
 					}
 				} else {
-					let fwd_session = self.fwd_udp_sessions.read().await.get(&assoc_id).cloned();
+					let fwd_session = self.fwd_udp_sessions.get(&assoc_id).await;
 
 					if let Some(session) = fwd_session {
 						if let Err(err) = session.send(pkt).await {

--- a/tuic-client/src/connection/mod.rs
+++ b/tuic-client/src/connection/mod.rs
@@ -1,6 +1,5 @@
 // Standard library imports for networking, synchronization, and timing
 use std::{
-	collections::HashMap,
 	net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket},
 	sync::{Arc, Mutex, atomic::AtomicU32},
 	time::Duration,
@@ -9,6 +8,7 @@ use std::{
 // Error handling and utility crates
 use anyhow::Context;
 use crossbeam_utils::atomic::AtomicCell;
+use moka::future::Cache;
 use quinn::{
 	ClientConfig, Connection as QuinnConnection, Endpoint as QuinnEndpoint, EndpointConfig, TokioRuntime, TransportConfig,
 	VarInt, ZeroRttAccepted,
@@ -40,8 +40,8 @@ mod socks5;
 use self::socks5::Socks5UdpSocket;
 
 /// Convenience type aliases for the two UDP session maps
-type Socks5Sessions = Arc<AsyncRwLock<HashMap<u16, crate::socks5::UdpSession>>>;
-type FwdSessions = Arc<AsyncRwLock<HashMap<u16, crate::forward::ForwardUdpSession>>>;
+type Socks5Sessions = Cache<u16, crate::socks5::UdpSession>;
+type FwdSessions = Cache<u16, crate::forward::ForwardUdpSession>;
 
 /// Default error code for QUIC connection
 pub const ERROR_CODE: VarInt = VarInt::from_u32(0);

--- a/tuic-client/src/forward.rs
+++ b/tuic-client/src/forward.rs
@@ -154,7 +154,7 @@ async fn run_udp_forwarder(entry: UdpForward, ctx: Arc<crate::AppContext>) {
 						let id = 0x8000 | (ctx.next_fwd_assoc_id.fetch_add(1, Ordering::Relaxed) & 0x7fff);
 						// register session
 						let session = ForwardUdpSession::new(socket.clone(), src_addr, id);
-						ctx.fwd_udp_sessions.write().await.insert(id, session);
+						ctx.fwd_udp_sessions.insert(id, session).await;
 						src_map.insert(src_addr, id);
 						// Spawn timeout watcher
 						tokio::spawn(expire_after(id, entry.timeout, ctx.clone()));
@@ -183,10 +183,8 @@ async fn run_udp_forwarder(entry: UdpForward, ctx: Arc<crate::AppContext>) {
 
 async fn expire_after(assoc_id: u16, timeout: Duration, ctx: Arc<crate::AppContext>) {
 	tokio::time::sleep(timeout).await;
-	let mut w = ctx.fwd_udp_sessions.write().await;
-	if let Some(_s) = w.remove(&assoc_id) {
+	if ctx.fwd_udp_sessions.remove(&assoc_id).await.is_some() {
 		debug!("[forward-udp] [{assoc:#06x}] timeout; dissociate", assoc = assoc_id);
-		drop(w);
 		if let Ok(conn) = ctx.get_conn().await {
 			if let Err(err) = conn.dissociate(assoc_id).await {
 				warn!("[forward-udp] [{assoc:#06x}] dissociate error: {err}", assoc = assoc_id);

--- a/tuic-client/src/lib.rs
+++ b/tuic-client/src/lib.rs
@@ -1,16 +1,14 @@
 // Library interface for tuic-client
 // This allows the client to be used as a library in integration tests
 
-use std::{
-	collections::HashMap,
-	sync::{
-		Arc,
-		atomic::{AtomicBool, AtomicU16, Ordering},
-	},
+use std::sync::{
+	Arc,
+	atomic::{AtomicBool, AtomicU16, Ordering},
 };
 
+use moka::future::Cache;
 use tokio::{
-	sync::{Mutex as AsyncMutex, RwLock as AsyncRwLock},
+	sync::Mutex as AsyncMutex,
 	time::{Duration, sleep},
 };
 use tracing::{error, warn};
@@ -33,9 +31,9 @@ pub struct AppContext {
 	/// SOCKS5 proxy server
 	pub socks5:              Arc<socks5::Server>,
 	/// UDP session registry for SOCKS5 UDP associate
-	pub socks5_udp_sessions: Arc<AsyncRwLock<HashMap<u16, socks5::UdpSession>>>,
+	pub socks5_udp_sessions: Cache<u16, socks5::UdpSession>,
 	/// UDP session registry for TCP/UDP port forwarding
-	pub fwd_udp_sessions:    Arc<AsyncRwLock<HashMap<u16, forward::ForwardUdpSession>>>,
+	pub fwd_udp_sessions:    Cache<u16, forward::ForwardUdpSession>,
 	/// Next association ID counter for UDP forwarding (high bit set to avoid
 	/// collisions with SOCKS5 IDs)
 	pub next_fwd_assoc_id:   AtomicU16,
@@ -112,8 +110,8 @@ pub async fn run(cfg: Config) -> eyre::Result<()> {
 	let ctx = Arc::new(AppContext {
 		conn_mgr,
 		socks5,
-		socks5_udp_sessions: Arc::new(AsyncRwLock::new(HashMap::new())),
-		fwd_udp_sessions: Arc::new(AsyncRwLock::new(HashMap::new())),
+		socks5_udp_sessions: Cache::new(1024),
+		fwd_udp_sessions: Cache::new(1024),
 		next_fwd_assoc_id: AtomicU16::new(0),
 		startup_mode,
 		first_connected: AtomicBool::new(false),

--- a/tuic-client/src/socks5/handle_task.rs
+++ b/tuic-client/src/socks5/handle_task.rs
@@ -30,13 +30,8 @@ impl Server {
 		);
 
 		// Check for existing session with same ID
-		{
-			let sessions = ctx.socks5_udp_sessions.read().await;
-			if sessions.contains_key(&assoc_id) {
-				warn!(
-					"[socks5] [{peer_addr}] [associate] [{assoc_id:#06x}] session ID already exists! This may cause conflicts"
-				);
-			}
+		if ctx.socks5_udp_sessions.contains_key(&assoc_id) {
+			warn!("[socks5] [{peer_addr}] [associate] [{assoc_id:#06x}] session ID already exists! This may cause conflicts");
 		}
 
 		match UdpSession::new(assoc_id, peer_addr, local_ip, dual_stack, max_pkt_size) {
@@ -52,9 +47,7 @@ impl Server {
 					}
 				};
 
-				{
-					ctx.socks5_udp_sessions.write().await.insert(assoc_id, session.clone());
-				}
+				ctx.socks5_udp_sessions.insert(assoc_id, session.clone()).await;
 
 				let ctx_loop = ctx.clone();
 				let handle_local_incoming_pkt = async move {
@@ -108,9 +101,7 @@ impl Server {
 
 				debug!("[socks5] [{peer_addr}] [associate] [{assoc_id:#06x}] stopped associating");
 
-				{
-					ctx.socks5_udp_sessions.write().await.remove(&assoc_id).unwrap();
-				}
+				ctx.socks5_udp_sessions.remove(&assoc_id).await.unwrap();
 
 				if let Ok(conn) = ctx.get_conn().await
 					&& let Err(err) = conn.dissociate(assoc_id).await

--- a/tuic-server/src/connection/handle_task.rs
+++ b/tuic-server/src/connection/handle_task.rs
@@ -1,6 +1,7 @@
 use std::{
 	io::{Error as IoError, ErrorKind},
 	net::{IpAddr, SocketAddr},
+	sync::Arc,
 };
 
 use bytes::Bytes;
@@ -328,14 +329,14 @@ impl Connection {
 				src_addr = addr
 			);
 
-			let session = match self.udp_sessions.get(&assoc_id).await {
+			let session = match self.udp_sessions.get(&assoc_id).await.and_then(|w| w.upgrade()) {
 				Some(s) => s,
 				None => {
 					let weak = UdpSession::new(self.ctx.clone(), self.clone(), assoc_id)?;
 					let strong = weak
 						.upgrade()
 						.ok_or_else(|| Error::Other(eyre!("UdpSession dropped before use")))?;
-					self.udp_sessions.insert(assoc_id, strong.clone()).await;
+					self.udp_sessions.insert(assoc_id, Arc::downgrade(&strong)).await;
 					strong
 				}
 			};
@@ -409,7 +410,9 @@ impl Connection {
 	pub async fn handle_dissociate(&self, assoc_id: u16) {
 		info!("[UDP-DROP] [{assoc_id:#06x}]");
 
-		if let Some(session) = self.udp_sessions.remove(&assoc_id).await {
+		if let Some(weak) = self.udp_sessions.remove(&assoc_id).await
+			&& let Some(session) = weak.upgrade()
+		{
 			session.close().await;
 		}
 	}

--- a/tuic-server/src/connection/handle_task.rs
+++ b/tuic-server/src/connection/handle_task.rs
@@ -1,5 +1,4 @@
 use std::{
-	collections::hash_map::Entry,
 	io::{Error as IoError, ErrorKind},
 	net::{IpAddr, SocketAddr},
 };
@@ -329,19 +328,16 @@ impl Connection {
 				src_addr = addr
 			);
 
-			let guard = self.udp_sessions.read().await;
-			let session = guard.get(&assoc_id).map(|v| v.to_owned());
-			drop(guard);
-			let session = match session {
-				Some(v) => v,
-				None => match self.udp_sessions.write().await.entry(assoc_id) {
-					Entry::Occupied(entry) => entry.get().clone(),
-					Entry::Vacant(entry) => {
-						let session = UdpSession::new(self.ctx.clone(), self.clone(), assoc_id)?;
-						entry.insert(session.clone());
-						session
-					}
-				},
+			let session = match self.udp_sessions.get(&assoc_id).await {
+				Some(s) => s,
+				None => {
+					let weak = UdpSession::new(self.ctx.clone(), self.clone(), assoc_id)?;
+					let strong = weak
+						.upgrade()
+						.ok_or_else(|| Error::Other(eyre!("UdpSession dropped before use")))?;
+					self.udp_sessions.insert(assoc_id, strong.clone()).await;
+					strong
+				}
 			};
 
 			// Resolve using default outbound and apply ACL
@@ -399,11 +395,7 @@ impl Connection {
 
 			let uuid = self.auth.get().ok_or_eyre("Unexpected authorization state")?;
 			restful::traffic_tx(&self.ctx, &uuid, pkt.len());
-			if let Some(session) = session.upgrade() {
-				session.send(pkt, socket_addr).await
-			} else {
-				Err(eyre!("UdpSession dropped already").into())
-			}
+			session.send(pkt, socket_addr).await
 		};
 
 		if let Err(err) = process.await {
@@ -417,9 +409,7 @@ impl Connection {
 	pub async fn handle_dissociate(&self, assoc_id: u16) {
 		info!("[UDP-DROP] [{assoc_id:#06x}]");
 
-		if let Some(session) = self.udp_sessions.write().await.remove(&assoc_id)
-			&& let Some(session) = session.upgrade()
-		{
+		if let Some(session) = self.udp_sessions.remove(&assoc_id).await {
 			session.close().await;
 		}
 	}

--- a/tuic-server/src/connection/handle_task.rs
+++ b/tuic-server/src/connection/handle_task.rs
@@ -1,7 +1,6 @@
 use std::{
 	io::{Error as IoError, ErrorKind},
 	net::{IpAddr, SocketAddr},
-	sync::Arc,
 };
 
 use bytes::Bytes;
@@ -329,15 +328,12 @@ impl Connection {
 				src_addr = addr
 			);
 
-			let session = match self.udp_sessions.get(&assoc_id).await.and_then(|w| w.upgrade()) {
+			let session = match self.udp_sessions.get(&assoc_id).await {
 				Some(s) => s,
 				None => {
-					let weak = UdpSession::new(self.ctx.clone(), self.clone(), assoc_id)?;
-					let strong = weak
-						.upgrade()
-						.ok_or_else(|| Error::Other(eyre!("UdpSession dropped before use")))?;
-					self.udp_sessions.insert(assoc_id, Arc::downgrade(&strong)).await;
-					strong
+					let session = UdpSession::new(self.ctx.clone(), self.clone(), assoc_id, self.udp_sessions.clone())?;
+					self.udp_sessions.insert(assoc_id, session.clone()).await;
+					session
 				}
 			};
 
@@ -410,9 +406,7 @@ impl Connection {
 	pub async fn handle_dissociate(&self, assoc_id: u16) {
 		info!("[UDP-DROP] [{assoc_id:#06x}]");
 
-		if let Some(weak) = self.udp_sessions.remove(&assoc_id).await
-			&& let Some(session) = weak.upgrade()
-		{
+		if let Some(session) = self.udp_sessions.remove(&assoc_id).await {
 			session.close().await;
 		}
 	}

--- a/tuic-server/src/connection/mod.rs
+++ b/tuic-server/src/connection/mod.rs
@@ -1,16 +1,16 @@
 use std::{
-	collections::HashMap,
-	sync::{Arc, Weak, atomic::AtomicU32},
+	sync::{Arc, atomic::AtomicU32},
 	time::Duration,
 };
 
 use arc_swap::ArcSwap;
 use bytes::Bytes;
+use moka::future::Cache;
 use peekable::tokio::AsyncPeekExt;
 use quinn::{Connecting, Connection as QuinnConnection, VarInt};
 use register_count::Counter;
 use smallvec::SmallVec;
-use tokio::{sync::RwLock as AsyncRwLock, time};
+use tokio::time;
 use tracing::{Instrument, Span, debug, info, info_span, warn};
 use tuic_core::quinn::{Authenticate, Connection as Model, side};
 
@@ -59,7 +59,7 @@ pub struct Connection {
 	inner: QuinnConnection,
 	model: Model<side::Server>,
 	auth: Authenticated,
-	udp_sessions: Arc<AsyncRwLock<HashMap<u16, Weak<UdpSession>>>>,
+	udp_sessions: Cache<u16, Arc<UdpSession>>,
 	udp_relay_mode: Arc<ArcSwap<Option<UdpRelayMode>>>,
 	remote_uni_stream_cnt: Counter,
 	remote_bi_stream_cnt: Counter,
@@ -175,7 +175,7 @@ impl Connection {
 			inner: conn.clone(),
 			model: Model::<side::Server>::new(conn),
 			auth: Authenticated::new(),
-			udp_sessions: Arc::new(AsyncRwLock::new(HashMap::new())),
+			udp_sessions: Cache::new(u16::MAX as u64),
 			udp_relay_mode: Arc::new(ArcSwap::new(None.into())),
 			remote_uni_stream_cnt: Counter::new(),
 			remote_bi_stream_cnt: Counter::new(),

--- a/tuic-server/src/connection/mod.rs
+++ b/tuic-server/src/connection/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-	sync::{Arc, Weak, atomic::AtomicU32},
+	sync::{Arc, atomic::AtomicU32},
 	time::Duration,
 };
 
@@ -59,7 +59,7 @@ pub struct Connection {
 	inner: QuinnConnection,
 	model: Model<side::Server>,
 	auth: Authenticated,
-	udp_sessions: Cache<u16, Weak<UdpSession>>,
+	udp_sessions: Cache<u16, Arc<UdpSession>>,
 	udp_relay_mode: Arc<ArcSwap<Option<UdpRelayMode>>>,
 	remote_uni_stream_cnt: Counter,
 	remote_bi_stream_cnt: Counter,

--- a/tuic-server/src/connection/mod.rs
+++ b/tuic-server/src/connection/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-	sync::{Arc, atomic::AtomicU32},
+	sync::{Arc, Weak, atomic::AtomicU32},
 	time::Duration,
 };
 
@@ -59,7 +59,7 @@ pub struct Connection {
 	inner: QuinnConnection,
 	model: Model<side::Server>,
 	auth: Authenticated,
-	udp_sessions: Cache<u16, Arc<UdpSession>>,
+	udp_sessions: Cache<u16, Weak<UdpSession>>,
 	udp_relay_mode: Arc<ArcSwap<Option<UdpRelayMode>>>,
 	remote_uni_stream_cnt: Counter,
 	remote_bi_stream_cnt: Counter,

--- a/tuic-server/src/connection/udp_session.rs
+++ b/tuic-server/src/connection/udp_session.rs
@@ -1,10 +1,11 @@
 use std::{
 	io::Error as IoError,
 	net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket as StdUdpSocket},
-	sync::{Arc, Weak},
+	sync::Arc,
 };
 
 use bytes::Bytes;
+use moka::future::Cache;
 use socket2::{Domain, Protocol, SockAddr, Socket, Type};
 use tokio::{
 	net::UdpSocket,
@@ -17,17 +18,26 @@ use super::Connection;
 use crate::{AppContext, error::Error, utils::FutResultExt};
 
 pub struct UdpSession {
-	ctx:       Arc<AppContext>,
-	assoc_id:  u16,
-	conn:      Connection,
-	socket_v4: UdpSocket,
-	socket_v6: Option<UdpSocket>,
-	close:     AsyncRwLock<Option<oneshot::Sender<()>>>,
+	ctx:          Arc<AppContext>,
+	assoc_id:     u16,
+	udp_sessions: Cache<u16, Arc<UdpSession>>,
+	socket_v4:    UdpSocket,
+	socket_v6:    Option<UdpSocket>,
+	close:        AsyncRwLock<Option<oneshot::Sender<()>>>,
 }
 
 impl UdpSession {
-	// spawn a task which actually owns itself, then return its wake reference.
-	pub fn new(ctx: Arc<AppContext>, conn: Connection, assoc_id: u16) -> Result<Weak<Self>, Error> {
+	/// Spawn a listen task for the UDP session and return an `Arc<Self>`.
+	///
+	/// The listen task is the session's real owner; when it ends the session
+	/// is dropped. `conn` is consumed and moved into the listen task for
+	/// outgoing packet relay (`relay_packet`).
+	pub fn new(
+		ctx: Arc<AppContext>,
+		conn: Connection,
+		assoc_id: u16,
+		udp_sessions: Cache<u16, Arc<UdpSession>>,
+	) -> Result<Arc<Self>, Error> {
 		let socket_v4 = {
 			let socket = Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP))
 				.map_err(|err| Error::Socket("failed to create UDP associate IPv4 socket", err))?;
@@ -66,22 +76,23 @@ impl UdpSession {
 
 		let (tx, rx) = oneshot::channel();
 
+		let ctx_listening = ctx.clone();
 		let session = Arc::new(Self {
-			ctx: ctx.clone(),
-			conn,
+			ctx,
 			assoc_id,
+			udp_sessions,
 			socket_v4,
 			socket_v6,
 			close: AsyncRwLock::new(Some(tx)),
 		});
 
 		let session_listening = session.clone();
-		// UdpSession's real owner.
+		let conn_listening = conn; // moved here, used by listen task for relay
 		let listen_span = Span::current();
 		let listen = async move {
 			let span = Span::current();
 			let mut rx = rx;
-			let mut timeout = tokio::time::interval(ctx.cfg.stream_timeout);
+			let mut timeout = tokio::time::interval(ctx_listening.cfg.stream_timeout);
 			timeout.reset();
 
 			loop {
@@ -110,19 +121,18 @@ impl UdpSession {
 				};
 
 				tokio::spawn(
-					session_listening
-						.conn
+					conn_listening
 						.clone()
 						.relay_packet(pkt, Address::SocketAddress(addr), session_listening.assoc_id)
 						.log_err()
 						.instrument(span.clone()),
 				);
 			}
-			session_listening.conn.udp_sessions.invalidate(&assoc_id).await;
+			session_listening.udp_sessions.invalidate(&assoc_id).await;
 		};
 
 		tokio::spawn(listen.instrument(listen_span));
-		Ok(Arc::downgrade(&session))
+		Ok(session)
 	}
 
 	pub async fn send(&self, pkt: Bytes, mut addr: SocketAddr) -> Result<(), Error> {

--- a/tuic-server/src/connection/udp_session.rs
+++ b/tuic-server/src/connection/udp_session.rs
@@ -118,7 +118,7 @@ impl UdpSession {
 						.instrument(span.clone()),
 				);
 			}
-			session_listening.conn.udp_sessions.write().await.remove(&assoc_id);
+			session_listening.conn.udp_sessions.invalidate(&assoc_id).await;
 		};
 
 		tokio::spawn(listen.instrument(listen_span));


### PR DESCRIPTION

## Changes

Replace  management paths with  for lock-free concurrent access.

