### PR TITLE
fix: remove double span entry causing conn:conn: log display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3495,7 +3495,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuic-client"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "anyhow",
  "aws-lc-rs",
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "tuic-core"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "bytes",
  "eyre",
@@ -3562,7 +3562,7 @@ dependencies = [
 
 [[package]]
 name = "tuic-server"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "arc-swap",
  "aws-lc-rs",
@@ -3625,7 +3625,7 @@ dependencies = [
 
 [[package]]
 name = "tuic-tests"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "aws-lc-rs",
  "eyre",

--- a/tuic-server/src/connection/mod.rs
+++ b/tuic-server/src/connection/mod.rs
@@ -92,8 +92,6 @@ impl Connection {
 					addr = %conn.inner.remote_address(),
 					user = tracing::field::Empty,
 				);
-				let _guard = conn_span.enter();
-				let conn_span = conn_span.clone();
 
 				if ctx.cfg.camouflage.as_ref().is_some_and(|cfg| cfg.enabled) {
 					match conn.classify_h3_dispatch().await {
@@ -101,7 +99,6 @@ impl Connection {
 							prefetched_uni,
 							prefetched_bi,
 						}) => {
-							drop(_guard);
 							if let Err(err) =
 								camouflage::handle(ctx.clone(), conn.inner.clone(), prefetched_uni, prefetched_bi).await
 							{
@@ -110,7 +107,7 @@ impl Connection {
 							return;
 						}
 						Ok(H3Dispatch::Tuic(first_event)) => {
-							info!("connection established");
+							info!(parent: &conn_span, "connection established");
 							tokio::spawn(
 								conn.clone()
 									.timeout_authenticate(ctx.cfg.auth_timeout)
@@ -140,26 +137,24 @@ impl Connection {
 								}
 							}
 
-							drop(_guard);
 							conn.run_tuic_event_loop().instrument(conn_span).await;
 							return;
 						}
 						Err(err) => {
-							warn!("classifier: {err}");
+							warn!(parent: &conn_span, "classifier: {err}");
 							conn.close();
 							return;
 						}
 					}
 				}
 
-				info!("connection established");
+				info!(parent: &conn_span, "connection established");
 				tokio::spawn(
 					conn.clone()
 						.timeout_authenticate(ctx.cfg.auth_timeout)
 						.instrument(conn_span.clone()),
 				);
 				tokio::spawn(conn.clone().collect_garbage().instrument(conn_span.clone()));
-				drop(_guard);
 				conn.run_tuic_event_loop().instrument(conn_span).await;
 			}
 			Err(err) if err.is_trivial() => {

--- a/tuic-server/src/connection/mod.rs
+++ b/tuic-server/src/connection/mod.rs
@@ -140,6 +140,7 @@ impl Connection {
 								}
 							}
 
+							drop(_guard);
 							conn.run_tuic_event_loop().instrument(conn_span).await;
 							return;
 						}
@@ -158,6 +159,7 @@ impl Connection {
 						.instrument(conn_span.clone()),
 				);
 				tokio::spawn(conn.clone().collect_garbage().instrument(conn_span.clone()));
+				drop(_guard);
 				conn.run_tuic_event_loop().instrument(conn_span).await;
 			}
 			Err(err) if err.is_trivial() => {


### PR DESCRIPTION
The connection span was being entered twice — once via `_guard = conn_span.enter()` and once via `run_tuic_event_loop().instrument(conn_span)`. This caused the compact log format to render `conn:conn:` prefix instead of a single `conn{...}`.

Fix: drop `_guard` before `run_tuic_event_loop().instrument(conn_span)` in both the camouflage-detection and non-camouflage paths.