### PR TITLE
fix: remove 64MB camouflage body cap that terminates HTTP/3 downloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3495,7 +3495,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuic-client"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "anyhow",
  "aws-lc-rs",
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "tuic-core"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "bytes",
  "eyre",
@@ -3562,7 +3562,7 @@ dependencies = [
 
 [[package]]
 name = "tuic-server"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "arc-swap",
  "aws-lc-rs",
@@ -3625,7 +3625,7 @@ dependencies = [
 
 [[package]]
 name = "tuic-tests"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "aws-lc-rs",
  "eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,6 +1198,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "h3-quinn"
+version = "0.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2e732c8d91a74731663ac8479ab505042fbf547b9a207213ab7fbcbfc4f8b4"
+dependencies = [
+ "bytes",
+ "futures",
+ "h3",
+ "quinn 0.11.9",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2145,6 +2159,7 @@ checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
  "cfg_aliases",
+ "futures-io",
  "pin-project-lite",
  "quinn-proto 0.11.14",
  "quinn-udp 0.5.14",
@@ -2193,6 +2208,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -3628,10 +3644,16 @@ name = "tuic-tests"
 version = "1.8.1"
 dependencies = [
  "aws-lc-rs",
+ "bytes",
  "eyre",
  "fast-socks5",
+ "futures",
+ "h3",
+ "h3-quinn",
+ "http",
  "json5 1.3.1",
  "lexopt",
+ "quinn 0.11.9",
  "rustls",
  "serial_test",
  "tokio",

--- a/tuic-server/src/camouflage.rs
+++ b/tuic-server/src/camouflage.rs
@@ -5,6 +5,7 @@ use axum::http::{
 	header::{HOST, HeaderValue},
 };
 use bytes::{Buf, Bytes};
+use futures::stream;
 use futures_util::StreamExt;
 use h3::server;
 use quinn::Connection;
@@ -12,9 +13,6 @@ use reqwest::{Client, Method, Url};
 use tracing::{debug, info, warn};
 
 use crate::{AppContext, config::CamouflageConfig};
-
-const MAX_REQUEST_BODY_SIZE: usize = 16 * 1024 * 1024;
-const MAX_RESPONSE_BODY_SIZE: usize = 64 * 1024 * 1024;
 
 pub async fn handle(
 	ctx: Arc<AppContext>,
@@ -40,21 +38,15 @@ pub async fn handle(
 	let mut h3_conn = server::Connection::new(quic_conn).await?;
 
 	while let Some(resolver) = h3_conn.accept().await? {
-		let (request, mut stream) = resolver.resolve_request().await?;
+		let (request, stream) = resolver.resolve_request().await?;
 		debug!(
 			"[camouflage] incoming h3 request: method={} uri={}",
 			request.method(),
 			request.uri()
 		);
 
-		match forward_request(&client, &backend, backend_host_override.as_deref(), request, &mut stream).await {
-			Ok(()) => {}
-			Err(err) => {
-				warn!("[camouflage] request forwarding failed: {err}");
-				let resp = Response::builder().status(502).body(())?;
-				_ = stream.send_response(resp).await;
-				_ = stream.finish().await;
-			}
+		if let Err(err) = forward_request(&client, &backend, backend_host_override.as_deref(), request, stream).await {
+			warn!("[camouflage] request forwarding failed: {err}");
 		}
 	}
 
@@ -95,10 +87,11 @@ async fn forward_request<S>(
 	backend: &Url,
 	backend_host_override: Option<&str>,
 	request: Request<()>,
-	stream: &mut server::RequestStream<S, Bytes>,
+	stream: server::RequestStream<S, Bytes>,
 ) -> eyre::Result<()>
 where
 	S: h3::quic::BidiStream<Bytes>,
+	<S as h3::quic::BidiStream<Bytes>>::RecvStream: Send + 'static,
 {
 	let target = rewrite_target_url(backend, request.uri())?;
 	let method = Method::from_bytes(request.method().as_str().as_bytes())?;
@@ -119,12 +112,31 @@ where
 		backend_request = backend_request.header(HOST, host);
 	}
 
-	let request_body = read_request_body(stream).await?;
-	if !request_body.is_empty() {
-		backend_request = backend_request.body(request_body);
-	}
+	let (mut send_half, recv_half) = stream.split();
 
-	let backend_response = backend_request.send().await?;
+	let body_stream = stream::unfold(Some(recv_half), |state| async move {
+		let mut recv = state?;
+		match recv.recv_data().await {
+			Ok(Some(mut chunk)) => {
+				let remaining = chunk.remaining();
+				let bytes = chunk.copy_to_bytes(remaining);
+				Some((Ok::<Bytes, std::io::Error>(bytes), Some(recv)))
+			}
+			Ok(None) => None,
+			Err(e) => Some((Err(std::io::Error::other(e.to_string())), None)),
+		}
+	});
+	backend_request = backend_request.body(reqwest::Body::wrap_stream(body_stream));
+
+	let backend_response = match backend_request.send().await {
+		Ok(resp) => resp,
+		Err(err) => {
+			let resp = Response::builder().status(502).body(())?;
+			let _ = send_half.send_response(resp).await;
+			let _ = send_half.finish().await;
+			return Err(err.into());
+		}
+	};
 	let status = backend_response.status();
 	let headers = backend_response.headers().clone();
 
@@ -135,48 +147,17 @@ where
 		}
 	}
 	let response = response.body(())?;
-	stream.send_response(response).await?;
+	send_half.send_response(response).await?;
 
-	let mut body_size = 0usize;
 	let mut body_stream = backend_response.bytes_stream();
 	while let Some(chunk) = body_stream.next().await {
 		let chunk = chunk?;
-		body_size += chunk.len();
-		if body_size > MAX_RESPONSE_BODY_SIZE {
-			return Err(eyre::eyre!(
-				"response body too large: {} bytes (max {})",
-				body_size,
-				MAX_RESPONSE_BODY_SIZE
-			));
-		}
 		if !chunk.is_empty() {
-			stream.send_data(chunk).await?;
+			send_half.send_data(chunk).await?;
 		}
 	}
-	stream.finish().await?;
+	send_half.finish().await?;
 	Ok(())
-}
-
-async fn read_request_body<S>(stream: &mut server::RequestStream<S, Bytes>) -> eyre::Result<Bytes>
-where
-	S: h3::quic::BidiStream<Bytes>,
-{
-	let mut body = Vec::new();
-
-	while let Some(mut chunk) = stream.recv_data().await? {
-		let remaining = chunk.remaining();
-		body.extend_from_slice(chunk.copy_to_bytes(remaining).as_ref());
-		if body.len() > MAX_REQUEST_BODY_SIZE {
-			return Err(eyre::eyre!(
-				"request body too large: {} bytes (max {})",
-				body.len(),
-				MAX_REQUEST_BODY_SIZE
-			));
-		}
-	}
-	let _ = stream.recv_trailers().await?;
-
-	Ok(Bytes::from(body))
 }
 
 fn rewrite_target_url(backend: &Url, uri: &Uri) -> eyre::Result<Url> {

--- a/tuic-tests/Cargo.toml
+++ b/tuic-tests/Cargo.toml
@@ -33,3 +33,15 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 serial_test = "3"
 aws-lc-rs = { version = "1", default-features = false, optional = true, features = ["prebuilt-nasm"] }
+
+[dev-dependencies]
+# HTTP/3 client for camouflage end-to-end test (issue #117).
+# Pinned to crates.io quinn 0.11 (separate from the forked quinn 0.12 that
+# tuic-server itself depends on) — distinct Rust types, but they interoperate
+# at the QUIC wire protocol.
+h3 = "0.0.8"
+h3-quinn = "0.0.10"
+quinn-stock = { package = "quinn", version = "0.11", default-features = false, features = ["runtime-tokio", "rustls-aws-lc-rs"] }
+http = "1"
+bytes = "1"
+futures = "0.3"

--- a/tuic-tests/tests/camouflage_64mb_test.rs
+++ b/tuic-tests/tests/camouflage_64mb_test.rs
@@ -1,0 +1,273 @@
+//! End-to-end regression test for issue #117: HTTP/3 camouflage path must
+//! stream responses larger than the previously-hard-coded 64 MiB cap without
+//! terminating the QUIC stream.
+//!
+//! Topology:
+//!   h3 client (this test)  --QUIC/h3-->  tuic-server (camouflage)
+//!                                            |
+//!                                            v
+//!                                         HTTP/1.1 backend (this test, 80 MiB body)
+//!
+//! NOTE: tuic-server depends on a forked quinn 0.12, but h3-quinn 0.0.10 only
+//! works with crates.io quinn 0.11. The two crates are imported separately
+//! (the latter aliased as `quinn_stock` in Cargo.toml) — they're distinct Rust
+//! types but interoperate over the QUIC wire.
+
+use std::{
+	collections::HashMap,
+	net::{Ipv4Addr, SocketAddr},
+	path::PathBuf,
+	sync::Arc,
+	time::Duration,
+};
+
+use bytes::Buf;
+use eyre::Context;
+use http::Request;
+use quinn_stock as quinn;
+use tokio::{
+	io::{AsyncReadExt, AsyncWriteExt},
+	net::{TcpListener, UdpSocket},
+	time::timeout,
+};
+use tracing::{error, info};
+use tuic_server::config::{CamouflageConfig, ExperimentalConfig, TlsConfig};
+
+/// 80 MiB — comfortably past the 64 MiB cap that issue #117 reports.
+const PAYLOAD_SIZE: usize = 80 * 1024 * 1024;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_camouflage_streams_more_than_64mb() -> eyre::Result<()> {
+	#[cfg(feature = "aws-lc-rs")]
+	let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+	#[cfg(feature = "ring")]
+	let _ = rustls::crypto::ring::default_provider().install_default();
+
+	let _ = tracing_subscriber::fmt()
+		.with_max_level(tracing::Level::INFO)
+		.with_test_writer()
+		.try_init();
+
+	// --- 1. backend -------------------------------------------------------
+	let backend_port = spawn_http_backend().await?;
+	info!("backend listening on 127.0.0.1:{backend_port}");
+
+	// --- 2. tuic-server with camouflage -----------------------------------
+	let server_port = pick_unused_udp_port().await?;
+	let cfg = tuic_server::Config {
+		log_level: tuic_server::config::LogLevel::Info,
+		server: format!("127.0.0.1:{server_port}").parse().unwrap(),
+		users: HashMap::new(),
+		tls: TlsConfig {
+			self_sign:   true,
+			certificate: PathBuf::new(),
+			private_key: PathBuf::new(),
+			alpn:        vec!["h3".to_string()],
+			hostname:    "localhost".to_string(),
+			auto_ssl:    false,
+			acme_email:  String::new(),
+		},
+		camouflage: Some(CamouflageConfig {
+			enabled:                 true,
+			reverse_proxy_url:       format!("http://127.0.0.1:{backend_port}"),
+			reverse_proxy_hostname:  None,
+			request_timeout:         Duration::from_secs(60),
+			skip_backend_tls_verify: true,
+		}),
+		data_dir: std::env::temp_dir(),
+		quic: tuic_server::config::QuicConfig::default(),
+		udp_relay_ipv6: false,
+		zero_rtt_handshake: false,
+		dual_stack: false,
+		experimental: ExperimentalConfig::default(),
+		..Default::default()
+	};
+
+	tokio::spawn(async move {
+		if let Err(e) = tuic_server::run(cfg).await {
+			error!("tuic-server exited: {e}");
+		}
+	});
+
+	// Poll until the server's UDP port answers, with a hard ceiling.
+	wait_for_quic_port(server_port).await?;
+
+	// --- 3. h3 client -----------------------------------------------------
+	let server_addr: SocketAddr = format!("127.0.0.1:{server_port}").parse().unwrap();
+
+	let mut client_crypto = rustls::ClientConfig::builder()
+		.dangerous()
+		.with_custom_certificate_verifier(Arc::new(SkipVerify::new()))
+		.with_no_client_auth();
+	client_crypto.alpn_protocols = vec![b"h3".to_vec()];
+
+	let client_config = quinn::ClientConfig::new(Arc::new(
+		quinn::crypto::rustls::QuicClientConfig::try_from(client_crypto).context("quic client config")?,
+	));
+	let mut endpoint = quinn::Endpoint::client("0.0.0.0:0".parse()?)?;
+	endpoint.set_default_client_config(client_config);
+
+	let conn = endpoint.connect(server_addr, "localhost")?.await?;
+	info!("QUIC connected to {server_addr}");
+
+	let h3_conn = h3_quinn::Connection::new(conn);
+	let (mut driver, mut send_request) = h3::client::new(h3_conn).await?;
+	let drive_handle = tokio::spawn(async move {
+		let _ = futures::future::poll_fn(|cx| driver.poll_close(cx)).await;
+	});
+
+	let req = Request::get("https://localhost/big").body(())?;
+	let mut stream = send_request.send_request(req).await?;
+	stream.finish().await?;
+
+	let resp = stream.recv_response().await?;
+	info!("h3 response status: {}", resp.status());
+	assert_eq!(resp.status(), 200, "expected 200 from camouflage proxy");
+
+	// --- 4. drain body and verify size ------------------------------------
+	let mut total = 0usize;
+	let read = async {
+		while let Some(mut chunk) = stream.recv_data().await? {
+			let n = chunk.remaining();
+			total += n;
+			chunk.advance(n);
+		}
+		Ok::<_, eyre::Report>(())
+	};
+	timeout(Duration::from_secs(120), read)
+		.await
+		.context("h3 body recv timed out")??;
+
+	info!("received {total} bytes (expected {PAYLOAD_SIZE})");
+	assert_eq!(
+		total, PAYLOAD_SIZE,
+		"camouflage truncated body before backend EOF — issue #117 regression"
+	);
+
+	drop(send_request);
+	drive_handle.abort();
+	endpoint.close(0u32.into(), b"done");
+	Ok(())
+}
+
+/// Trivial single-shot HTTP/1.1 server: drains the request, then writes
+/// an 80 MiB body in 64 KiB chunks of a deterministic byte pattern.
+async fn spawn_http_backend() -> eyre::Result<u16> {
+	let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0u16)).await?;
+	let port = listener.local_addr()?.port();
+	tokio::spawn(async move {
+		loop {
+			let Ok((mut sock, _)) = listener.accept().await else {
+				return;
+			};
+			tokio::spawn(async move {
+				// Drain headers (read until \r\n\r\n or 64 KiB).
+				let mut buf = vec![0u8; 8192];
+				let mut acc = Vec::with_capacity(4096);
+				loop {
+					match sock.read(&mut buf).await {
+						Ok(0) => return,
+						Ok(n) => {
+							acc.extend_from_slice(&buf[..n]);
+							if acc.windows(4).any(|w| w == b"\r\n\r\n") || acc.len() > 64 * 1024 {
+								break;
+							}
+						}
+						Err(_) => return,
+					}
+				}
+
+				let header = format!(
+					"HTTP/1.1 200 OK\r\nContent-Length: {PAYLOAD_SIZE}\r\nContent-Type: \
+					 application/octet-stream\r\nConnection: close\r\n\r\n"
+				);
+				if sock.write_all(header.as_bytes()).await.is_err() {
+					return;
+				}
+				let chunk = vec![0xA5u8; 64 * 1024];
+				let mut sent = 0usize;
+				while sent < PAYLOAD_SIZE {
+					let n = (PAYLOAD_SIZE - sent).min(chunk.len());
+					if sock.write_all(&chunk[..n]).await.is_err() {
+						return;
+					}
+					sent += n;
+				}
+				let _ = sock.shutdown().await;
+			});
+		}
+	});
+	Ok(port)
+}
+
+async fn pick_unused_udp_port() -> eyre::Result<u16> {
+	let s = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0u16)).await?;
+	Ok(s.local_addr()?.port())
+}
+
+/// Give the spawned tuic-server task time to bind its UDP socket. tuic-server
+/// initializes synchronously inside `run()` then blocks on `accept()`, so a
+/// short fixed wait is enough — the QUIC handshake itself will retry if the
+/// first datagram races the bind.
+async fn wait_for_quic_port(_port: u16) -> eyre::Result<()> {
+	tokio::time::sleep(Duration::from_millis(750)).await;
+	Ok(())
+}
+
+// ---- skip-verify cert verifier ----------------------------------------------
+#[derive(Debug)]
+struct SkipVerify {
+	provider: Arc<rustls::crypto::CryptoProvider>,
+}
+impl SkipVerify {
+	fn new() -> Self {
+		Self {
+			provider: rustls::crypto::CryptoProvider::get_default()
+				.cloned()
+				.unwrap_or_else(|| {
+					#[cfg(feature = "aws-lc-rs")]
+					{
+						Arc::new(rustls::crypto::aws_lc_rs::default_provider())
+					}
+					#[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
+					{
+						Arc::new(rustls::crypto::ring::default_provider())
+					}
+				}),
+		}
+	}
+}
+impl rustls::client::danger::ServerCertVerifier for SkipVerify {
+	fn verify_server_cert(
+		&self,
+		_: &rustls::pki_types::CertificateDer<'_>,
+		_: &[rustls::pki_types::CertificateDer<'_>],
+		_: &rustls::pki_types::ServerName<'_>,
+		_: &[u8],
+		_: rustls::pki_types::UnixTime,
+	) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+		Ok(rustls::client::danger::ServerCertVerified::assertion())
+	}
+
+	fn verify_tls12_signature(
+		&self,
+		_: &[u8],
+		_: &rustls::pki_types::CertificateDer<'_>,
+		_: &rustls::DigitallySignedStruct,
+	) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+		Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+	}
+
+	fn verify_tls13_signature(
+		&self,
+		_: &[u8],
+		_: &rustls::pki_types::CertificateDer<'_>,
+		_: &rustls::DigitallySignedStruct,
+	) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+		Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+	}
+
+	fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+		self.provider.signature_verification_algorithms.supported_schemes()
+	}
+}


### PR DESCRIPTION
## Summary

Fixes [#117](https://github.com/Itsusinn/tuic/issues/117) — when `tuic-server` is used as an HTTP/3 camouflage reverse proxy, browser downloads (and video streams) over QUIC are interrupted at exactly 64 MB.

Root cause is not QUIC `receive_window` (the maintainer's initial guess) — it's a hard-coded `MAX_RESPONSE_BODY_SIZE = 64 MiB` constant in `tuic-server/src/camouflage.rs`. After accumulating 64 MB of forwarded response bytes, `forward_request` returns `Err`, which finishes the H3 stream prematurely. From the browser's side this looks like a terminated QUIC connection.

A symmetrical 16 MB cap (`MAX_REQUEST_BODY_SIZE`) on the request side fully buffered request bodies in memory and rejected larger uploads.

## Changes

- Removed both `MAX_RESPONSE_BODY_SIZE` and `MAX_REQUEST_BODY_SIZE` constants.
- Response side: dropped the `body_size` accumulator/check; chunks now stream end-to-end without an artificial cap. QUIC stream flow control (`stream_receive_window`, `send_window`) still bounds memory.
- Request side: replaced the buffered `read_request_body` (which read the whole body into a `Vec<u8>`) with a streaming `reqwest::Body::wrap_stream` adapter built on `futures::stream::unfold` over the H3 receive half. Large uploads now also pass through.
- Restructured `forward_request` to take ownership of `RequestStream` and `split()` it; the 502-on-backend-failure path moved inside `forward_request` since the stream is consumed there.

No new config fields. Users wanting to tune memory/throughput already have `[quic].receive_window` and `[quic].send_window`.

Out of scope: the maintainer's separate suggestion to swap `quinn` for `quiche`/`boringssl` for fingerprint reasons.

## Test plan

- [x] `cargo build -p tuic-server`
- [x] `cargo test -p tuic-server --lib` — 120 passed, 0 failed
- [x] `cargo clippy -p tuic-server --all-targets` — clean
- [ ] End-to-end: configure `[camouflage]` with a backend serving a >100 MB file, download via an HTTP/3 browser (Edge/Chrome with `alt-svc`), confirm completion past the previous ~64 MB cutoff
- [ ] Regression: small file (<1 MB) and a typical web page still load through the camouflage path
- [ ] Optional upload check: `curl --http3 -X POST --data-binary @largefile ...` against an echo backend with body > 16 MB

Assisted-by: Claude:claude-opus-4-7