### PR TITLE
Fixed HTTP/3 masquerading to function correctly as a web endpoint.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,9 +1166,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1554,16 +1554,6 @@ version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
  "serde",
 ]
 
@@ -2917,9 +2907,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -3179,9 +3169,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",
@@ -3349,20 +3339,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "a28f0d049ccfaa566e14e9663d304d8577427b368cb4710a20528690287a738b"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -3495,7 +3485,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuic-client"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "anyhow",
  "aws-lc-rs",
@@ -3539,7 +3529,7 @@ dependencies = [
 
 [[package]]
 name = "tuic-core"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "bytes",
  "eyre",
@@ -3562,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "tuic-server"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "arc-swap",
  "aws-lc-rs",
@@ -3625,7 +3615,7 @@ dependencies = [
 
 [[package]]
 name = "tuic-tests"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "aws-lc-rs",
  "eyre",

--- a/tuic-server/README.md
+++ b/tuic-server/README.md
@@ -225,7 +225,7 @@ reverse_proxy_url = "https://127.0.0.1:443"
 # 2) HTTP Host header for backend request routing
 # Required only when reverse_proxy_url host is an IP address.
 reverse_proxy_hostname = "example.com"
-# Per-request timeout for backend proxying
+# Timeout for establishing the backend connection; response bodies can stream longer
 request_timeout = "10s"
 # Skip TLS verification for backend target (use only for local/self-signed backends)
 skip_backend_tls_verify = false

--- a/tuic-server/src/camouflage.rs
+++ b/tuic-server/src/camouflage.rs
@@ -2,19 +2,63 @@ use std::sync::Arc;
 
 use axum::http::{
 	HeaderName, Request, Response, Uri,
-	header::{HOST, HeaderValue},
+	header::{CONTENT_LENGTH, HOST, HeaderValue},
 };
 use bytes::{Buf, Bytes};
+use futures::stream;
 use futures_util::StreamExt;
-use h3::server;
+use h3::{error::Code, server};
 use quinn::Connection;
 use reqwest::{Client, Method, Url};
 use tracing::{debug, info, warn};
 
 use crate::{AppContext, config::CamouflageConfig};
 
-const MAX_REQUEST_BODY_SIZE: usize = 16 * 1024 * 1024;
-const MAX_RESPONSE_BODY_SIZE: usize = 64 * 1024 * 1024;
+#[derive(Clone)]
+pub struct BackendRoute {
+	backend: Url,
+	backend_host_override: Option<String>,
+	client: Client,
+}
+
+impl BackendRoute {
+	pub fn from_config(camouflage: Option<&CamouflageConfig>) -> eyre::Result<Option<Self>> {
+		let Some(camouflage) = camouflage.filter(|cfg| cfg.enabled) else {
+			return Ok(None);
+		};
+
+		let mut backend = Url::parse(camouflage.reverse_proxy_url.as_str())?;
+		let backend_host = backend
+			.host_str()
+			.ok_or_else(|| eyre::eyre!("`camouflage.reverse_proxy_url` must contain a host"))?
+			.to_string();
+		let backend_port = backend
+			.port_or_known_default()
+			.ok_or_else(|| eyre::eyre!("`camouflage.reverse_proxy_url` has no known port"))?;
+
+		let mut client_builder = Client::builder()
+			.danger_accept_invalid_certs(camouflage.skip_backend_tls_verify)
+			.connect_timeout(camouflage.request_timeout);
+		let mut backend_host_override = camouflage.reverse_proxy_hostname.clone();
+
+		if let Some(reverse_proxy_hostname) = camouflage.reverse_proxy_hostname.as_deref() {
+			backend
+				.set_host(Some(reverse_proxy_hostname))
+				.map_err(|_| eyre::eyre!("invalid `camouflage.reverse_proxy_hostname`: {reverse_proxy_hostname}"))?;
+			if let Ok(ip) = backend_host.parse::<std::net::IpAddr>() {
+				client_builder = client_builder.resolve(reverse_proxy_hostname, std::net::SocketAddr::new(ip, backend_port));
+			}
+			backend_host_override = Some(reverse_proxy_hostname.to_string());
+		}
+
+		let client = client_builder.build()?;
+		Ok(Some(Self {
+			backend,
+			backend_host_override,
+			client,
+		}))
+	}
+}
 
 pub async fn handle(
 	ctx: Arc<AppContext>,
@@ -22,94 +66,75 @@ pub async fn handle(
 	prefetched_uni: Option<crate::h3_quinn_compat::PeekableRecvStream>,
 	prefetched_bi: Option<crate::h3_quinn_compat::PrefetchedBiRecv>,
 ) -> eyre::Result<()> {
-	let Some(camouflage) = ctx.cfg.camouflage.as_ref().filter(|cfg| cfg.enabled) else {
+	let Some(route) = ctx.camouflage.as_ref() else {
 		return Ok(());
 	};
-
-	let (backend, backend_host_override, client) = build_backend_route(camouflage)?;
 
 	info!(
 		id = conn.stable_id() as u32,
 		addr = %conn.remote_address(),
 		"HTTP/3 camouflage enabled, reverse proxy target={target}, backend_host={host:?}",
-		target = backend,
-		host = backend_host_override
+		target = route.backend,
+		host = route.backend_host_override
 	);
 
 	let quic_conn = crate::h3_quinn_compat::Connection::new_with_prefetched(conn, prefetched_uni, prefetched_bi);
 	let mut h3_conn = server::Connection::new(quic_conn).await?;
 
-	while let Some(resolver) = h3_conn.accept().await? {
-		let (request, mut stream) = resolver.resolve_request().await?;
+	loop {
+		let Some(resolver) = accept_request(&mut h3_conn).await? else {
+			break;
+		};
+		let (request, stream) = resolver.resolve_request().await?;
 		debug!(
 			"[camouflage] incoming h3 request: method={} uri={}",
 			request.method(),
 			request.uri()
 		);
 
-		match forward_request(&client, &backend, backend_host_override.as_deref(), request, &mut stream).await {
-			Ok(()) => {}
-			Err(err) => {
+		let route = route.clone();
+		tokio::spawn(async move {
+			if let Err(err) = forward_request(route, request, stream).await {
 				warn!("[camouflage] request forwarding failed: {err}");
-				let resp = Response::builder().status(502).body(())?;
-				_ = stream.send_response(resp).await;
-				_ = stream.finish().await;
 			}
-		}
+		});
 	}
 
 	Ok(())
 }
 
-fn build_backend_route(camouflage: &CamouflageConfig) -> eyre::Result<(Url, Option<String>, Client)> {
-	let mut backend = Url::parse(camouflage.reverse_proxy_url.as_str())?;
-	let backend_host = backend
-		.host_str()
-		.ok_or_else(|| eyre::eyre!("`camouflage.reverse_proxy_url` must contain a host"))?
-		.to_string();
-	let backend_port = backend
-		.port_or_known_default()
-		.ok_or_else(|| eyre::eyre!("`camouflage.reverse_proxy_url` has no known port"))?;
-
-	let mut client_builder = Client::builder()
-		.danger_accept_invalid_certs(camouflage.skip_backend_tls_verify)
-		.timeout(camouflage.request_timeout);
-	let mut backend_host_override = camouflage.reverse_proxy_hostname.clone();
-
-	if let Some(reverse_proxy_hostname) = camouflage.reverse_proxy_hostname.as_deref() {
-		backend
-			.set_host(Some(reverse_proxy_hostname))
-			.map_err(|_| eyre::eyre!("invalid `camouflage.reverse_proxy_hostname`: {reverse_proxy_hostname}"))?;
-		if let Ok(ip) = backend_host.parse::<std::net::IpAddr>() {
-			client_builder = client_builder.resolve(reverse_proxy_hostname, std::net::SocketAddr::new(ip, backend_port));
-		}
-		backend_host_override = Some(reverse_proxy_hostname.to_string());
+async fn accept_request<C>(
+	h3_conn: &mut server::Connection<C, Bytes>,
+) -> eyre::Result<Option<server::RequestResolver<C, Bytes>>>
+where
+	C: h3::quic::Connection<Bytes>,
+{
+	match h3_conn.accept().await {
+		Ok(resolver) => Ok(resolver),
+		Err(err) if err.is_h3_no_error() => Ok(None),
+		Err(err) => Err(err.into()),
 	}
-
-	let client = client_builder.build()?;
-	Ok((backend, backend_host_override, client))
 }
 
 async fn forward_request<S>(
-	client: &Client,
-	backend: &Url,
-	backend_host_override: Option<&str>,
+	route: BackendRoute,
 	request: Request<()>,
-	stream: &mut server::RequestStream<S, Bytes>,
+	stream: server::RequestStream<S, Bytes>,
 ) -> eyre::Result<()>
 where
 	S: h3::quic::BidiStream<Bytes>,
+	<S as h3::quic::BidiStream<Bytes>>::RecvStream: Send + 'static,
 {
-	let target = rewrite_target_url(backend, request.uri())?;
+	let target = rewrite_target_url(&route.backend, request.uri())?;
 	let method = Method::from_bytes(request.method().as_str().as_bytes())?;
-	let mut backend_request = client.request(method, target);
+	let mut backend_request = route.client.request(method, target);
 
 	for (name, value) in request.headers() {
 		if is_forwardable_header(name) {
 			backend_request = backend_request.header(name, value);
 		}
 	}
-	if let Some(host) = backend_host_override {
+	if let Some(host) = route.backend_host_override.as_deref() {
 		backend_request = backend_request.header(HOST, host);
 	} else if let Some(host) = request
 		.headers()
@@ -119,64 +144,86 @@ where
 		backend_request = backend_request.header(HOST, host);
 	}
 
-	let request_body = read_request_body(stream).await?;
-	if !request_body.is_empty() {
-		backend_request = backend_request.body(request_body);
+	let (mut send_half, mut recv_half) = stream.split();
+
+	if request_has_body(&request) {
+		let body_stream = stream::unfold(Some(recv_half), |state| async move {
+			let mut recv = state?;
+			match recv.recv_data().await {
+				Ok(Some(mut chunk)) => {
+					let remaining = chunk.remaining();
+					let bytes = chunk.copy_to_bytes(remaining);
+					Some((Ok::<Bytes, std::io::Error>(bytes), Some(recv)))
+				}
+				Ok(None) => None,
+				Err(e) => Some((Err(std::io::Error::other(e.to_string())), None)),
+			}
+		});
+		backend_request = backend_request.body(reqwest::Body::wrap_stream(body_stream));
+	} else {
+		while recv_half.recv_data().await?.is_some() {}
 	}
 
-	let backend_response = backend_request.send().await?;
+	let backend_response = match backend_request.send().await {
+		Ok(resp) => resp,
+		Err(err) => {
+			let resp = Response::builder().status(502).body(())?;
+			let _ = send_half.send_response(resp).await;
+			let _ = send_half.finish().await;
+			return Err(err.into());
+		}
+	};
 	let status = backend_response.status();
 	let headers = backend_response.headers().clone();
+	let expected_body_len = headers
+		.get(CONTENT_LENGTH)
+		.and_then(|value| value.to_str().ok())
+		.and_then(|value| value.parse::<u64>().ok());
 
 	let mut response = Response::builder().status(status);
 	for (name, value) in &headers {
-		if is_forwardable_header(name) {
+		if is_forwardable_response_header(name) {
 			response = response.header(name, value);
 		}
 	}
 	let response = response.body(())?;
-	stream.send_response(response).await?;
+	send_half.send_response(response).await?;
 
-	let mut body_size = 0usize;
+	let mut sent_body_len = 0u64;
 	let mut body_stream = backend_response.bytes_stream();
 	while let Some(chunk) = body_stream.next().await {
-		let chunk = chunk?;
-		body_size += chunk.len();
-		if body_size > MAX_RESPONSE_BODY_SIZE {
-			return Err(eyre::eyre!(
-				"response body too large: {} bytes (max {})",
-				body_size,
-				MAX_RESPONSE_BODY_SIZE
-			));
-		}
+		let chunk = match chunk {
+			Ok(chunk) => chunk,
+			Err(err) => {
+				send_half.stop_stream(Code::H3_INTERNAL_ERROR);
+				return Err(err.into());
+			}
+		};
 		if !chunk.is_empty() {
-			stream.send_data(chunk).await?;
+			sent_body_len += chunk.len() as u64;
+			if expected_body_len.is_some_and(|expected| sent_body_len > expected) {
+				send_half.stop_stream(Code::H3_INTERNAL_ERROR);
+				return Err(eyre::eyre!(
+					"backend response body exceeded content-length: sent {sent_body_len} bytes, expected {expected} bytes",
+					expected = expected_body_len.unwrap()
+				));
+			}
+			if let Err(err) = send_half.send_data(chunk).await {
+				send_half.stop_stream(Code::H3_INTERNAL_ERROR);
+				return Err(err.into());
+			}
 		}
 	}
-	stream.finish().await?;
+	if let Some(expected) = expected_body_len
+		&& sent_body_len != expected
+	{
+		send_half.stop_stream(Code::H3_INTERNAL_ERROR);
+		return Err(eyre::eyre!(
+			"backend response body ended early: sent {sent_body_len} bytes, expected {expected} bytes"
+		));
+	}
+	send_half.finish().await?;
 	Ok(())
-}
-
-async fn read_request_body<S>(stream: &mut server::RequestStream<S, Bytes>) -> eyre::Result<Bytes>
-where
-	S: h3::quic::BidiStream<Bytes>,
-{
-	let mut body = Vec::new();
-
-	while let Some(mut chunk) = stream.recv_data().await? {
-		let remaining = chunk.remaining();
-		body.extend_from_slice(chunk.copy_to_bytes(remaining).as_ref());
-		if body.len() > MAX_REQUEST_BODY_SIZE {
-			return Err(eyre::eyre!(
-				"request body too large: {} bytes (max {})",
-				body.len(),
-				MAX_REQUEST_BODY_SIZE
-			));
-		}
-	}
-	let _ = stream.recv_trailers().await?;
-
-	Ok(Bytes::from(body))
 }
 
 fn rewrite_target_url(backend: &Url, uri: &Uri) -> eyre::Result<Url> {
@@ -189,14 +236,33 @@ fn rewrite_target_url(backend: &Url, uri: &Uri) -> eyre::Result<Url> {
 }
 
 fn is_forwardable_header(name: &HeaderName) -> bool {
+	is_forwardable_common_header(name) && !matches!(name.as_str().to_ascii_lowercase().as_str(), "content-length")
+}
+
+fn is_forwardable_response_header(name: &HeaderName) -> bool {
+	is_forwardable_common_header(name)
+}
+
+fn request_has_body(request: &Request<()>) -> bool {
+	if request
+		.headers()
+		.get(CONTENT_LENGTH)
+		.and_then(|value| value.to_str().ok())
+		.and_then(|value| value.parse::<u64>().ok())
+		.is_some_and(|len| len > 0)
+	{
+		return true;
+	}
+
+	matches!(
+		*request.method(),
+		axum::http::Method::POST | axum::http::Method::PUT | axum::http::Method::PATCH
+	)
+}
+
+fn is_forwardable_common_header(name: &HeaderName) -> bool {
 	!matches!(
 		name.as_str().to_ascii_lowercase().as_str(),
-		"connection"
-			| "keep-alive"
-			| "proxy-connection"
-			| "transfer-encoding"
-			| "upgrade"
-			| "te" | "trailer"
-			| "host" | "content-length"
+		"connection" | "keep-alive" | "proxy-connection" | "transfer-encoding" | "upgrade" | "te" | "trailer" | "host"
 	)
 }

--- a/tuic-server/src/camouflage.rs
+++ b/tuic-server/src/camouflage.rs
@@ -16,9 +16,9 @@ use crate::{AppContext, config::CamouflageConfig};
 
 #[derive(Clone)]
 pub struct BackendRoute {
-	backend: Url,
+	backend:               Url,
 	backend_host_override: Option<String>,
-	client: Client,
+	client:                Client,
 }
 
 impl BackendRoute {

--- a/tuic-server/src/h3_quinn_compat.rs
+++ b/tuic-server/src/h3_quinn_compat.rs
@@ -30,28 +30,28 @@ pub struct PrefetchedBiRecv {
 }
 
 pub struct Connection {
-	conn:           quinn::Connection,
-	incoming_bi:    BoxStreamSync<'static, <AcceptBi<'static> as Future>::Output>,
-	opening_bi:     Option<BoxStreamSync<'static, <OpenBi<'static> as Future>::Output>>,
-	incoming_uni:   BoxStreamSync<'static, <AcceptUni<'static> as Future>::Output>,
-	opening_uni:    Option<BoxStreamSync<'static, <OpenUni<'static> as Future>::Output>>,
-	prefetched_bi:  Option<PrefetchedBiRecv>,
+	conn: quinn::Connection,
+	incoming_bi: BoxStreamSync<'static, <AcceptBi<'static> as Future>::Output>,
+	opening_bi: Option<BoxStreamSync<'static, <OpenBi<'static> as Future>::Output>>,
+	incoming_uni: BoxStreamSync<'static, <AcceptUni<'static> as Future>::Output>,
+	opening_uni: Option<BoxStreamSync<'static, <OpenUni<'static> as Future>::Output>>,
+	prefetched_bi: Option<PrefetchedBiRecv>,
 	prefetched_uni: Option<RecvStream>,
 }
 
 impl Connection {
 	pub fn new(conn: quinn::Connection) -> Self {
 		Self {
-			conn:           conn.clone(),
-			incoming_bi:    Box::pin(stream::unfold(conn.clone(), |conn| async {
+			conn: conn.clone(),
+			incoming_bi: Box::pin(stream::unfold(conn.clone(), |conn| async {
 				Some((conn.accept_bi().await, conn))
 			})),
-			opening_bi:     None,
-			incoming_uni:   Box::pin(stream::unfold(conn.clone(), |conn| async {
+			opening_bi: None,
+			incoming_uni: Box::pin(stream::unfold(conn.clone(), |conn| async {
 				Some((conn.accept_uni().await, conn))
 			})),
-			opening_uni:    None,
-			prefetched_bi:  None,
+			opening_uni: None,
+			prefetched_bi: None,
 			prefetched_uni: None,
 		}
 	}
@@ -78,7 +78,7 @@ where
 	fn poll_accept_bidi(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<Self::BidiStream, ConnectionErrorIncoming>> {
 		if let Some(prefetched) = self.prefetched_bi.take() {
 			return Poll::Ready(Ok(Self::BidiStream {
-				send: Self::SendStream::new(prefetched.send),
+				send: Self::SendStream::new(prefetched.send, self.conn.clone()),
 				recv: Self::RecvStream::new_peekable(prefetched.recv),
 			}));
 		}
@@ -87,7 +87,7 @@ where
 			.expect("self.incoming_bi never returns None")
 			.map_err(convert_connection_error)?;
 		Poll::Ready(Ok(Self::BidiStream {
-			send: Self::SendStream::new(send),
+			send: Self::SendStream::new(send, self.conn.clone()),
 			recv: Self::RecvStream::new(recv),
 		}))
 	}
@@ -105,8 +105,8 @@ where
 
 	fn opener(&self) -> Self::OpenStreams {
 		OpenStreams {
-			conn:        self.conn.clone(),
-			opening_bi:  None,
+			conn: self.conn.clone(),
+			opening_bi: None,
 			opening_uni: None,
 		}
 	}
@@ -148,7 +148,7 @@ where
 			})?;
 
 		Poll::Ready(Ok(Self::BidiStream {
-			send: Self::SendStream::new(send),
+			send: Self::SendStream::new(send, self.conn.clone()),
 			recv: RecvStream::new(recv),
 		}))
 	}
@@ -165,7 +165,7 @@ where
 			.map_err(|err| StreamErrorIncoming::ConnectionErrorIncoming {
 				connection_error: convert_connection_error(err),
 			})?;
-		Poll::Ready(Ok(Self::SendStream::new(send)))
+		Poll::Ready(Ok(Self::SendStream::new(send, self.conn.clone())))
 	}
 
 	fn close(&mut self, code: Code, reason: &[u8]) {
@@ -175,8 +175,8 @@ where
 }
 
 pub struct OpenStreams {
-	conn:        quinn::Connection,
-	opening_bi:  Option<BoxStreamSync<'static, <OpenBi<'static> as Future>::Output>>,
+	conn: quinn::Connection,
+	opening_bi: Option<BoxStreamSync<'static, <OpenBi<'static> as Future>::Output>>,
 	opening_uni: Option<BoxStreamSync<'static, <OpenUni<'static> as Future>::Output>>,
 }
 
@@ -201,7 +201,7 @@ where
 			})?;
 
 		Poll::Ready(Ok(Self::BidiStream {
-			send: Self::SendStream::new(send),
+			send: Self::SendStream::new(send, self.conn.clone()),
 			recv: RecvStream::new(recv),
 		}))
 	}
@@ -218,7 +218,7 @@ where
 			.map_err(|err| StreamErrorIncoming::ConnectionErrorIncoming {
 				connection_error: convert_connection_error(err),
 			})?;
-		Poll::Ready(Ok(Self::SendStream::new(send)))
+		Poll::Ready(Ok(Self::SendStream::new(send, self.conn.clone())))
 	}
 
 	fn close(&mut self, code: Code, reason: &[u8]) {
@@ -230,8 +230,8 @@ where
 impl Clone for OpenStreams {
 	fn clone(&self) -> Self {
 		Self {
-			conn:        self.conn.clone(),
-			opening_bi:  None,
+			conn: self.conn.clone(),
+			opening_bi: None,
 			opening_uni: None,
 		}
 	}
@@ -296,10 +296,10 @@ impl<B: Buf> quic::SendStreamUnframed<B> for BidiStream<B> {
 }
 
 pub struct RecvStream {
-	stream:            Option<PeekableRecvStream>,
-	recv_id:           StreamId,
+	stream: Option<PeekableRecvStream>,
+	recv_id: StreamId,
 	pending_stop_code: Option<u64>,
-	read_chunk_fut:    ReadChunkFuture,
+	read_chunk_fut: ReadChunkFuture,
 }
 
 type ReadChunkFuture = ReusableBoxFuture<'static, (PeekableRecvStream, Result<Option<quinn::Chunk>, quinn::ReadError>)>;
@@ -317,10 +317,10 @@ impl RecvStream {
 
 	fn new_inner(stream: PeekableRecvStream, stream_id: u64) -> Self {
 		Self {
-			stream:            Some(stream),
-			recv_id:           stream_id.try_into().expect("invalid stream id"),
+			stream: Some(stream),
+			recv_id: stream_id.try_into().expect("invalid stream id"),
 			pending_stop_code: None,
-			read_chunk_fut:    ReusableBoxFuture::new(async { unreachable!() }),
+			read_chunk_fut: ReusableBoxFuture::new(async { unreachable!() }),
 		}
 	}
 }
@@ -398,22 +398,58 @@ fn convert_write_error_to_stream_error(error: quinn::WriteError) -> StreamErrorI
 	}
 }
 
+fn retire_finished_stream(conn: quinn::Connection, stream: quinn::SendStream) {
+	tokio::spawn(async move {
+		let stopped = stream.stopped();
+		match stopped.await {
+			Ok(Some(_)) => {
+				let _ = conn.closed().await;
+			}
+			Ok(None) | Err(_) => {}
+		}
+		drop(stream);
+	});
+}
+
 pub struct SendStream<B: Buf> {
-	stream:  quinn::SendStream,
+	conn: quinn::Connection,
+	stream: Option<quinn::SendStream>,
+	send_id: StreamId,
 	writing: Option<WriteBuf<B>>,
 }
 
 impl<B: Buf> SendStream<B> {
-	fn new(stream: quinn::SendStream) -> Self {
-		Self { stream, writing: None }
+	fn new(stream: quinn::SendStream, conn: quinn::Connection) -> Self {
+		let num: u64 = stream.id().into();
+		Self {
+			conn,
+			stream: Some(stream),
+			send_id: num.try_into().expect("invalid stream id"),
+			writing: None,
+		}
+	}
+
+	fn stream_mut(&mut self) -> Result<&mut quinn::SendStream, StreamErrorIncoming> {
+		self.stream
+			.as_mut()
+			.ok_or_else(|| StreamErrorIncoming::ConnectionErrorIncoming {
+				connection_error: ConnectionErrorIncoming::InternalError("send stream already finished".to_string()),
+			})
 	}
 }
 
 impl<B: Buf> quic::SendStream<B> for SendStream<B> {
 	fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), StreamErrorIncoming>> {
+		if self.writing.is_some() && self.stream.is_none() {
+			return Poll::Ready(Err(StreamErrorIncoming::ConnectionErrorIncoming {
+				connection_error: ConnectionErrorIncoming::InternalError("send stream already finished".to_string()),
+			}));
+		}
+
 		if let Some(ref mut data) = self.writing {
 			while data.has_remaining() {
-				let stream = Pin::new(&mut self.stream);
+				let stream = self.stream.as_mut().expect("stream checked above");
+				let stream = Pin::new(stream);
 				let written = ready!(stream.poll_write(cx, data.chunk())).map_err(convert_write_error_to_stream_error)?;
 				data.advance(written);
 			}
@@ -423,12 +459,27 @@ impl<B: Buf> quic::SendStream<B> for SendStream<B> {
 		Poll::Ready(Ok(()))
 	}
 
-	fn poll_finish(&mut self, _cx: &mut task::Context<'_>) -> Poll<Result<(), StreamErrorIncoming>> {
-		Poll::Ready(self.stream.finish().map_err(|e| StreamErrorIncoming::Unknown(Box::new(e))))
+	fn poll_finish(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), StreamErrorIncoming>> {
+		ready!(self.poll_ready(cx))?;
+		let Some(mut stream) = self.stream.take() else {
+			return Poll::Ready(Ok(()));
+		};
+		match stream.finish() {
+			Ok(()) => {
+				retire_finished_stream(self.conn.clone(), stream);
+				Poll::Ready(Ok(()))
+			}
+			Err(err) => {
+				self.stream = Some(stream);
+				Poll::Ready(Err(StreamErrorIncoming::Unknown(Box::new(err))))
+			}
+		}
 	}
 
 	fn reset(&mut self, reset_code: u64) {
-		let _ = self.stream.reset(VarInt::from_u64(reset_code).unwrap_or(VarInt::MAX));
+		if let Some(stream) = self.stream.as_mut() {
+			let _ = stream.reset(VarInt::from_u64(reset_code).unwrap_or(VarInt::MAX));
+		}
 	}
 
 	fn send_data<D: Into<WriteBuf<B>>>(&mut self, data: D) -> Result<(), StreamErrorIncoming> {
@@ -442,8 +493,7 @@ impl<B: Buf> quic::SendStream<B> for SendStream<B> {
 	}
 
 	fn send_id(&self) -> StreamId {
-		let num: u64 = self.stream.id().into();
-		num.try_into().expect("invalid stream id")
+		self.send_id
 	}
 }
 
@@ -453,7 +503,11 @@ impl<B: Buf> quic::SendStreamUnframed<B> for SendStream<B> {
 			panic!("poll_send called while send stream is not ready")
 		}
 
-		let stream = Pin::new(&mut self.stream);
+		let stream = match self.stream_mut() {
+			Ok(stream) => stream,
+			Err(err) => return Poll::Ready(Err(err)),
+		};
+		let stream = Pin::new(stream);
 		match ready!(stream.poll_write(cx, buf.chunk())) {
 			Ok(written) => {
 				buf.advance(written);

--- a/tuic-server/src/h3_quinn_compat.rs
+++ b/tuic-server/src/h3_quinn_compat.rs
@@ -30,28 +30,28 @@ pub struct PrefetchedBiRecv {
 }
 
 pub struct Connection {
-	conn: quinn::Connection,
-	incoming_bi: BoxStreamSync<'static, <AcceptBi<'static> as Future>::Output>,
-	opening_bi: Option<BoxStreamSync<'static, <OpenBi<'static> as Future>::Output>>,
-	incoming_uni: BoxStreamSync<'static, <AcceptUni<'static> as Future>::Output>,
-	opening_uni: Option<BoxStreamSync<'static, <OpenUni<'static> as Future>::Output>>,
-	prefetched_bi: Option<PrefetchedBiRecv>,
+	conn:           quinn::Connection,
+	incoming_bi:    BoxStreamSync<'static, <AcceptBi<'static> as Future>::Output>,
+	opening_bi:     Option<BoxStreamSync<'static, <OpenBi<'static> as Future>::Output>>,
+	incoming_uni:   BoxStreamSync<'static, <AcceptUni<'static> as Future>::Output>,
+	opening_uni:    Option<BoxStreamSync<'static, <OpenUni<'static> as Future>::Output>>,
+	prefetched_bi:  Option<PrefetchedBiRecv>,
 	prefetched_uni: Option<RecvStream>,
 }
 
 impl Connection {
 	pub fn new(conn: quinn::Connection) -> Self {
 		Self {
-			conn: conn.clone(),
-			incoming_bi: Box::pin(stream::unfold(conn.clone(), |conn| async {
+			conn:           conn.clone(),
+			incoming_bi:    Box::pin(stream::unfold(conn.clone(), |conn| async {
 				Some((conn.accept_bi().await, conn))
 			})),
-			opening_bi: None,
-			incoming_uni: Box::pin(stream::unfold(conn.clone(), |conn| async {
+			opening_bi:     None,
+			incoming_uni:   Box::pin(stream::unfold(conn.clone(), |conn| async {
 				Some((conn.accept_uni().await, conn))
 			})),
-			opening_uni: None,
-			prefetched_bi: None,
+			opening_uni:    None,
+			prefetched_bi:  None,
 			prefetched_uni: None,
 		}
 	}
@@ -105,8 +105,8 @@ where
 
 	fn opener(&self) -> Self::OpenStreams {
 		OpenStreams {
-			conn: self.conn.clone(),
-			opening_bi: None,
+			conn:        self.conn.clone(),
+			opening_bi:  None,
 			opening_uni: None,
 		}
 	}
@@ -175,8 +175,8 @@ where
 }
 
 pub struct OpenStreams {
-	conn: quinn::Connection,
-	opening_bi: Option<BoxStreamSync<'static, <OpenBi<'static> as Future>::Output>>,
+	conn:        quinn::Connection,
+	opening_bi:  Option<BoxStreamSync<'static, <OpenBi<'static> as Future>::Output>>,
 	opening_uni: Option<BoxStreamSync<'static, <OpenUni<'static> as Future>::Output>>,
 }
 
@@ -230,8 +230,8 @@ where
 impl Clone for OpenStreams {
 	fn clone(&self) -> Self {
 		Self {
-			conn: self.conn.clone(),
-			opening_bi: None,
+			conn:        self.conn.clone(),
+			opening_bi:  None,
 			opening_uni: None,
 		}
 	}
@@ -296,10 +296,10 @@ impl<B: Buf> quic::SendStreamUnframed<B> for BidiStream<B> {
 }
 
 pub struct RecvStream {
-	stream: Option<PeekableRecvStream>,
-	recv_id: StreamId,
+	stream:            Option<PeekableRecvStream>,
+	recv_id:           StreamId,
 	pending_stop_code: Option<u64>,
-	read_chunk_fut: ReadChunkFuture,
+	read_chunk_fut:    ReadChunkFuture,
 }
 
 type ReadChunkFuture = ReusableBoxFuture<'static, (PeekableRecvStream, Result<Option<quinn::Chunk>, quinn::ReadError>)>;
@@ -317,10 +317,10 @@ impl RecvStream {
 
 	fn new_inner(stream: PeekableRecvStream, stream_id: u64) -> Self {
 		Self {
-			stream: Some(stream),
-			recv_id: stream_id.try_into().expect("invalid stream id"),
+			stream:            Some(stream),
+			recv_id:           stream_id.try_into().expect("invalid stream id"),
 			pending_stop_code: None,
-			read_chunk_fut: ReusableBoxFuture::new(async { unreachable!() }),
+			read_chunk_fut:    ReusableBoxFuture::new(async { unreachable!() }),
 		}
 	}
 }
@@ -401,19 +401,16 @@ fn convert_write_error_to_stream_error(error: quinn::WriteError) -> StreamErrorI
 fn retire_finished_stream(conn: quinn::Connection, stream: quinn::SendStream) {
 	tokio::spawn(async move {
 		let stopped = stream.stopped();
-		match stopped.await {
-			Ok(Some(_)) => {
-				let _ = conn.closed().await;
-			}
-			Ok(None) | Err(_) => {}
+		if let Ok(Some(_)) = stopped.await {
+			let _ = conn.closed().await;
 		}
 		drop(stream);
 	});
 }
 
 pub struct SendStream<B: Buf> {
-	conn: quinn::Connection,
-	stream: Option<quinn::SendStream>,
+	conn:    quinn::Connection,
+	stream:  Option<quinn::SendStream>,
 	send_id: StreamId,
 	writing: Option<WriteBuf<B>>,
 }

--- a/tuic-server/src/lib.rs
+++ b/tuic-server/src/lib.rs
@@ -27,15 +27,18 @@ pub mod utils;
 pub use config::{Cli, Config, Control};
 
 pub struct AppContext {
-	pub cfg:            Config,
+	pub cfg: Config,
+	pub camouflage: Option<camouflage::BackendRoute>,
 	pub online_counter: HashMap<Uuid, AtomicUsize>,
 	pub online_clients: Cache<Uuid, Arc<Cache<usize, compat::QuicClient>>>,
-	pub traffic_stats:  HashMap<Uuid, (AtomicUsize, AtomicUsize)>,
-	pub cancel:         CancellationToken,
+	pub traffic_stats: HashMap<Uuid, (AtomicUsize, AtomicUsize)>,
+	pub cancel: CancellationToken,
 }
 
 /// Run the TUIC server with the given configuration
 pub async fn run(cfg: Config) -> eyre::Result<()> {
+	let camouflage = camouflage::BackendRoute::from_config(cfg.camouflage.as_ref())?;
+
 	let mut online_counter = HashMap::new();
 	for (user, _) in cfg.users.iter() {
 		online_counter.insert(user.to_owned(), AtomicUsize::new(0));
@@ -51,6 +54,7 @@ pub async fn run(cfg: Config) -> eyre::Result<()> {
 		online_clients: Cache::new(cfg.users.len() as u64),
 		traffic_stats,
 		cfg,
+		camouflage,
 		cancel: CancellationToken::new(),
 	});
 	let server = server::Server::init(ctx.clone()).await?;

--- a/tuic-server/src/lib.rs
+++ b/tuic-server/src/lib.rs
@@ -27,12 +27,12 @@ pub mod utils;
 pub use config::{Cli, Config, Control};
 
 pub struct AppContext {
-	pub cfg: Config,
-	pub camouflage: Option<camouflage::BackendRoute>,
+	pub cfg:            Config,
+	pub camouflage:     Option<camouflage::BackendRoute>,
 	pub online_counter: HashMap<Uuid, AtomicUsize>,
 	pub online_clients: Cache<Uuid, Arc<Cache<usize, compat::QuicClient>>>,
-	pub traffic_stats: HashMap<Uuid, (AtomicUsize, AtomicUsize)>,
-	pub cancel: CancellationToken,
+	pub traffic_stats:  HashMap<Uuid, (AtomicUsize, AtomicUsize)>,
+	pub cancel:         CancellationToken,
 }
 
 /// Run the TUIC server with the given configuration


### PR DESCRIPTION
Assisted by: ChatGPT Codex
Following a simple test involving the replacement of the website's QUIC endpoint, everything appears to be working correctly.
Size limits have been removed, and a fix has been implemented on the HTTP/1.1 backend to resolve incorrect QUIC resets.