### PR TITLE
refactor: use tuic-core re-exported quinn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,41 +669,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
-dependencies = [
- "darling_core",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1492,12 +1457,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2126,18 +2085,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "qlog"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13932f4f3e6b912a43b3af40a3174614b8408c85059b79ef23fe1b3c87e5d04a"
-dependencies = [
- "humantime",
- "serde",
- "serde_json",
- "serde_with",
-]
-
-[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2218,7 +2165,6 @@ dependencies = [
  "fastbloom",
  "getrandom 0.3.4",
  "lru-slab",
- "qlog",
  "rand 0.9.4",
  "rand_pcg",
  "ring",
@@ -2731,7 +2677,6 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -2778,28 +2723,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_with"
-version = "3.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
-dependencies = [
- "serde_core",
- "serde_with_macros",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3495,7 +3495,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuic-client"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "anyhow",
  "aws-lc-rs",
@@ -3513,8 +3513,6 @@ dependencies = [
  "moka",
  "num_cpus",
  "once_cell",
- "quinn 0.12.0",
- "quinn-congestions",
  "register-count",
  "rustls",
  "rustls-native-certs",
@@ -3539,7 +3537,7 @@ dependencies = [
 
 [[package]]
 name = "tuic-core"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "bytes",
  "eyre",
@@ -3547,6 +3545,7 @@ dependencies = [
  "parking_lot",
  "peekable",
  "quinn 0.12.0",
+ "quinn-congestions",
  "rcgen 0.14.7",
  "register-count",
  "rustls",
@@ -3562,7 +3561,7 @@ dependencies = [
 
 [[package]]
 name = "tuic-server"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "arc-swap",
  "aws-lc-rs",
@@ -3591,8 +3590,6 @@ dependencies = [
  "peekable",
  "pest",
  "pest_derive",
- "quinn 0.12.0",
- "quinn-congestions",
  "rand 0.10.1",
  "rcgen 0.14.7",
  "regex",
@@ -3625,7 +3622,7 @@ dependencies = [
 
 [[package]]
 name = "tuic-tests"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "aws-lc-rs",
  "eyre",

--- a/tuic-client/Cargo.toml
+++ b/tuic-client/Cargo.toml
@@ -13,8 +13,8 @@ repository.workspace = true
 
 [features]
 default = ["aws-lc-rs"]
-ring = ["tuic-core/ring", "rustls/ring", "quinn/rustls-ring"]
-aws-lc-rs = ["tuic-core/aws-lc-rs", "dep:aws-lc-rs", "rustls/aws-lc-rs", "quinn/rustls-aws-lc-rs"]
+ring = ["tuic-core/ring", "rustls/ring"]
+aws-lc-rs = ["tuic-core/aws-lc-rs", "dep:aws-lc-rs", "rustls/aws-lc-rs"]
 jemallocator = ["tikv-jemallocator"]
 
 [dependencies]
@@ -38,10 +38,6 @@ socks5-proto = { version = "0.3", default-features = false }
 socks5-server = { version = "0.8", default-features = false }
 
 uuid = { version = "1", default-features = false, features = ["serde", "std"] }
-
-# QUIC
-quinn = { workspace = true, default-features = false, features = ["runtime-tokio","qlog"] }
-quinn-congestions = { workspace = true }
 
 # TUIC
 tuic-core = { path = "../tuic-core", default-features = false, features = ["async_marshal", "marshal", "model"] }

--- a/tuic-client/src/connection/handle_stream.rs
+++ b/tuic-client/src/connection/handle_stream.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::Ordering;
 
 use bytes::Bytes;
-use quinn::{RecvStream, SendStream, VarInt};
+use tuic_core::quinn::{RecvStream, SendStream, VarInt};
 use register_count::Register;
 use tracing::{debug, warn};
 use tuic_core::quinn::Task;

--- a/tuic-client/src/connection/handle_stream.rs
+++ b/tuic-client/src/connection/handle_stream.rs
@@ -1,10 +1,9 @@
 use std::sync::atomic::Ordering;
 
 use bytes::Bytes;
-use tuic_core::quinn::{RecvStream, SendStream, VarInt};
 use register_count::Register;
 use tracing::{debug, warn};
-use tuic_core::quinn::Task;
+use tuic_core::quinn::{RecvStream, SendStream, Task, VarInt};
 
 use super::Connection;
 use crate::{error::Error, utils::UdpRelayMode};

--- a/tuic-client/src/connection/handle_task.rs
+++ b/tuic-client/src/connection/handle_task.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use bytes::Bytes;
-use quinn::ZeroRttAccepted;
+use tuic_core::quinn::ZeroRttAccepted;
 use socks5_proto::Address as Socks5Address;
 use tokio::time;
 use tracing::{debug, info, warn};

--- a/tuic-client/src/connection/handle_task.rs
+++ b/tuic-client/src/connection/handle_task.rs
@@ -1,13 +1,12 @@
 use std::time::Duration;
 
 use bytes::Bytes;
-use tuic_core::quinn::ZeroRttAccepted;
 use socks5_proto::Address as Socks5Address;
 use tokio::time;
 use tracing::{debug, info, warn};
 use tuic_core::{
 	Address,
-	quinn::{Connect, Packet},
+	quinn::{Connect, Packet, ZeroRttAccepted},
 };
 
 use super::Connection;

--- a/tuic-client/src/connection/mod.rs
+++ b/tuic-client/src/connection/mod.rs
@@ -9,13 +9,13 @@ use std::{
 use anyhow::Context;
 use crossbeam_utils::atomic::AtomicCell;
 use moka::future::Cache;
-use quinn::{
-	ClientConfig, Connection as QuinnConnection, Endpoint as QuinnEndpoint, EndpointConfig, TokioRuntime, TransportConfig,
+use tuic_core::quinn::{
+	ClientConfig, QuinnConnection, Endpoint as QuinnEndpoint, EndpointConfig, TokioRuntime, TransportConfig,
 	VarInt, ZeroRttAccepted,
 	congestion::{Bbr3Config, CubicConfig, NewRenoConfig},
 	crypto::rustls::QuicClientConfig,
+	bbr::BbrConfig,
 };
-use quinn_congestions::bbr::BbrConfig;
 use register_count::Counter;
 use rustls::{
 	ClientConfig as RustlsClientConfig,

--- a/tuic-client/src/connection/mod.rs
+++ b/tuic-client/src/connection/mod.rs
@@ -9,13 +9,6 @@ use std::{
 use anyhow::Context;
 use crossbeam_utils::atomic::AtomicCell;
 use moka::future::Cache;
-use tuic_core::quinn::{
-	ClientConfig, QuinnConnection, Endpoint as QuinnEndpoint, EndpointConfig, TokioRuntime, TransportConfig,
-	VarInt, ZeroRttAccepted,
-	congestion::{Bbr3Config, CubicConfig, NewRenoConfig},
-	crypto::rustls::QuicClientConfig,
-	bbr::BbrConfig,
-};
 use register_count::Counter;
 use rustls::{
 	ClientConfig as RustlsClientConfig,
@@ -23,6 +16,13 @@ use rustls::{
 };
 use tokio::{sync::RwLock as AsyncRwLock, time};
 use tracing::{debug, info, warn};
+use tuic_core::quinn::{
+	ClientConfig, Endpoint as QuinnEndpoint, EndpointConfig, QuinnConnection, TokioRuntime, TransportConfig, VarInt,
+	ZeroRttAccepted,
+	bbr::BbrConfig,
+	congestion::{Bbr3Config, CubicConfig, NewRenoConfig},
+	crypto::rustls::QuicClientConfig,
+};
 // Importing custom QUIC connection model and side marker
 use tuic_core::quinn::{Connection as Model, side};
 use uuid::Uuid;

--- a/tuic-client/src/connection/socks5.rs
+++ b/tuic-client/src/connection/socks5.rs
@@ -6,7 +6,7 @@ use std::{
 	task::{Context, Poll},
 };
 
-use quinn::{
+use tuic_core::quinn::{
 	AsyncUdpSocket, UdpSender,
 	udp::{RecvMeta, Transmit},
 };
@@ -70,7 +70,7 @@ impl UdpSender for Socks5UdpSender {
 }
 
 impl AsyncUdpSocket for Socks5UdpSocket {
-	fn create_sender(&self) -> Pin<Box<dyn quinn::UdpSender>> {
+	fn create_sender(&self) -> Pin<Box<dyn tuic_core::quinn::UdpSender>> {
 		Box::pin(Socks5UdpSender(Arc::new(self.clone())))
 	}
 

--- a/tuic-client/src/connection/socks5.rs
+++ b/tuic-client/src/connection/socks5.rs
@@ -6,12 +6,12 @@ use std::{
 	task::{Context, Poll},
 };
 
+use tokio::{io::ReadBuf, net::UdpSocket};
+use tracing::debug;
 use tuic_core::quinn::{
 	AsyncUdpSocket, UdpSender,
 	udp::{RecvMeta, Transmit},
 };
-use tokio::{io::ReadBuf, net::UdpSocket};
-use tracing::debug;
 
 #[derive(Debug, Clone)]
 pub struct Socks5UdpSocket {

--- a/tuic-client/src/error.rs
+++ b/tuic-client/src/error.rs
@@ -1,9 +1,8 @@
 use std::io::Error as IoError;
 
-use tuic_core::quinn::{ConnectError, ConnectionError};
 use rustls::Error as RustlsError;
 use thiserror::Error;
-use tuic_core::quinn::Error as ModelError;
+use tuic_core::quinn::{ConnectError, ConnectionError, Error as ModelError};
 
 #[derive(Debug, Error)]
 pub enum Error {

--- a/tuic-client/src/error.rs
+++ b/tuic-client/src/error.rs
@@ -1,6 +1,6 @@
 use std::io::Error as IoError;
 
-use quinn::{ConnectError, ConnectionError};
+use tuic_core::quinn::{ConnectError, ConnectionError};
 use rustls::Error as RustlsError;
 use thiserror::Error;
 use tuic_core::quinn::Error as ModelError;

--- a/tuic-core/Cargo.toml
+++ b/tuic-core/Cargo.toml
@@ -15,8 +15,8 @@ repository.workspace = true
 async_marshal = ["futures-util"]
 marshal = []
 model = ["parking_lot", "register-count"]
-ring = ["rustls/ring", "tokio-rustls/ring"]
-aws-lc-rs = ["rustls/aws-lc-rs", "tokio-rustls/aws-lc-rs"]
+ring = ["rustls/ring", "tokio-rustls/ring", "quinn/rustls-ring"]
+aws-lc-rs = ["rustls/aws-lc-rs", "tokio-rustls/aws-lc-rs", "quinn/rustls-aws-lc-rs"]
 
 [dependencies]
 # From tuic
@@ -31,7 +31,8 @@ serde = { version = "1", default-features = false, features = ["derive", "std"] 
 
 # From tuic-quinn
 tracing = { version = "0.1", default-features = false}
-quinn = { workspace = true, default-features = false, features = ["futures-io"]}
+quinn = { workspace = true, default-features = false, features = ["futures-io", "runtime-tokio", "qlog"]}
+quinn-congestions = { workspace = true }
 tokio = { version = "1", default-features = false, features = ["io-util"] }
 eyre = { version = "0.6" }
 

--- a/tuic-core/Cargo.toml
+++ b/tuic-core/Cargo.toml
@@ -31,7 +31,7 @@ serde = { version = "1", default-features = false, features = ["derive", "std"] 
 
 # From tuic-quinn
 tracing = { version = "0.1", default-features = false}
-quinn = { workspace = true, default-features = false, features = ["futures-io", "runtime-tokio", "qlog"]}
+quinn = { workspace = true, default-features = false, features = ["futures-io", "runtime-tokio"]}
 quinn-congestions = { workspace = true }
 tokio = { version = "1", default-features = false, features = ["io-util"] }
 eyre = { version = "0.6" }

--- a/tuic-core/src/lib.rs
+++ b/tuic-core/src/lib.rs
@@ -1,3 +1,5 @@
+pub extern crate quinn as quinn_crate;
+
 mod protocol;
 
 pub use self::protocol::{Address, Authenticate, Connect, Dissociate, Header, Heartbeat, Packet, VERSION};
@@ -18,7 +20,10 @@ pub mod model;
 mod tests;
 
 // Quinn integration module
-pub mod quinn;
+mod quinn_impl;
+pub mod quinn {
+	pub use super::quinn_impl::*;
+}
 
 // Utility types
 mod utils;

--- a/tuic-core/src/quinn_impl.rs
+++ b/tuic-core/src/quinn_impl.rs
@@ -6,8 +6,10 @@ use std::{
 	time::Duration,
 };
 
-pub use ::quinn;
-use ::quinn::{Connection as QuinnConnection, ConnectionError, RecvStream, SendDatagramError, SendStream, VarInt};
+pub use quinn_crate::*;
+pub use quinn_crate::Connection as QuinnConnection;
+pub use quinn_congestions;
+pub use quinn_congestions::bbr;
 use bytes::{BufMut, Bytes, BytesMut};
 use peekable::{buffer::Buffer, tokio::AsyncPeekable};
 use thiserror::Error;
@@ -41,41 +43,41 @@ pub mod side {
 /// Trait abstracting QUIC send stream operations.
 pub trait StreamTx: tokio::io::AsyncWrite + futures_util::AsyncWrite + Unpin + Send {
 	/// Notify the peer that no more data will be written to this stream.
-	fn finish(&mut self) -> Result<(), ::quinn::ClosedStream>;
+	fn finish(&mut self) -> Result<(), quinn_crate::ClosedStream>;
 	/// Wait for the stream to be stopped or read to completion by the peer.
-	fn stopped(&mut self) -> impl std::future::Future<Output = Result<Option<VarInt>, ::quinn::StoppedError>> + Send;
+	fn stopped(&mut self) -> impl std::future::Future<Output = Result<Option<quinn_crate::VarInt>, quinn_crate::StoppedError>> + Send;
 	/// Close the send stream immediately with the given error code.
-	fn reset(&mut self, error_code: VarInt) -> Result<(), ::quinn::ClosedStream>;
+	fn reset(&mut self, error_code: quinn_crate::VarInt) -> Result<(), quinn_crate::ClosedStream>;
 }
 
 /// Trait abstracting QUIC receive stream operations.
 pub trait StreamRx: tokio::io::AsyncRead + Unpin + Send {
 	/// Stop accepting data and notify the peer to stop transmitting.
-	fn stop(&mut self, error_code: VarInt) -> Result<(), ::quinn::ClosedStream>;
+	fn stop(&mut self, error_code: quinn_crate::VarInt) -> Result<(), quinn_crate::ClosedStream>;
 }
 
-impl StreamTx for ::quinn::SendStream {
-	fn finish(&mut self) -> Result<(), ::quinn::ClosedStream> {
-		SendStream::finish(self)
+impl StreamTx for quinn_crate::SendStream {
+	fn finish(&mut self) -> Result<(), quinn_crate::ClosedStream> {
+		quinn_crate::SendStream::finish(self)
 	}
 
-	fn stopped(&mut self) -> impl std::future::Future<Output = Result<Option<VarInt>, ::quinn::StoppedError>> + Send {
-		SendStream::stopped(self)
+	fn stopped(&mut self) -> impl std::future::Future<Output = Result<Option<quinn_crate::VarInt>, quinn_crate::StoppedError>> + Send {
+		quinn_crate::SendStream::stopped(self)
 	}
 
-	fn reset(&mut self, error_code: VarInt) -> Result<(), ::quinn::ClosedStream> {
-		SendStream::reset(self, error_code)
+	fn reset(&mut self, error_code: quinn_crate::VarInt) -> Result<(), quinn_crate::ClosedStream> {
+		quinn_crate::SendStream::reset(self, error_code)
 	}
 }
 
-impl StreamRx for ::quinn::RecvStream {
-	fn stop(&mut self, error_code: VarInt) -> Result<(), ::quinn::ClosedStream> {
-		RecvStream::stop(self, error_code)
+impl StreamRx for quinn_crate::RecvStream {
+	fn stop(&mut self, error_code: quinn_crate::VarInt) -> Result<(), quinn_crate::ClosedStream> {
+		quinn_crate::RecvStream::stop(self, error_code)
 	}
 }
 
 impl<R: StreamRx, B: Buffer + Send> StreamRx for AsyncPeekable<R, B> {
-	fn stop(&mut self, error_code: VarInt) -> Result<(), ::quinn::ClosedStream> {
+	fn stop(&mut self, error_code: quinn_crate::VarInt) -> Result<(), quinn_crate::ClosedStream> {
 		let (_, inner) = self.get_mut();
 		inner.stop(error_code)
 	}
@@ -87,7 +89,7 @@ impl<R: StreamRx, B: Buffer + Send> StreamRx for AsyncPeekable<R, B> {
 /// operations.
 #[derive(Clone)]
 pub struct Connection<Side> {
-	conn:    QuinnConnection,
+	conn:    quinn_crate::Connection,
 	model:   ConnectionModel<Bytes>,
 	_marker: Side,
 }
@@ -96,7 +98,7 @@ impl<Side> Connection<Side> {
 	/// Sends a `Packet` using UDP relay mode `native`.
 	pub fn packet_native(&self, pkt: impl AsRef<[u8]>, addr: Address, assoc_id: u16) -> eyre::Result<()> {
 		let Some(max_pkt_size) = self.conn.max_datagram_size() else {
-			return Err(Error::SendDatagram(SendDatagramError::Disabled))?;
+			return Err(Error::SendDatagram(quinn_crate::SendDatagramError::Disabled))?;
 		};
 
 		let model = self.model.send_packet(assoc_id, addr, max_pkt_size);
@@ -148,7 +150,7 @@ impl<Side> Connection<Side> {
 
 impl Connection<side::Client> {
 	/// Creates a new client side `Connection`.
-	pub fn new(conn: QuinnConnection) -> Self {
+	pub fn new(conn: quinn_crate::Connection) -> Self {
 		Self {
 			conn,
 			model: ConnectionModel::new(),
@@ -198,7 +200,7 @@ impl Connection<side::Client> {
 	///
 	/// The stream should be accepted by `quinn::Connection::accept_uni()`
 	/// from the same `QuinnConnection`.
-	pub async fn accept_uni_stream<R: StreamRx>(&self, mut recv: R) -> Result<Task<SendStream, R>, Error> {
+	pub async fn accept_uni_stream<R: StreamRx>(&self, mut recv: R) -> Result<Task<quinn_crate::SendStream, R>, Error> {
 		let header = match Header::async_unmarshal(&mut recv).await {
 			Ok(header) => header,
 			Err(err) => return Err(Error::UnmarshalUniStream(err)),
@@ -274,7 +276,7 @@ impl Connection<side::Client> {
 
 impl Connection<side::Server> {
 	/// Creates a new server side `Connection`.
-	pub fn new(conn: QuinnConnection) -> Self {
+	pub fn new(conn: quinn_crate::Connection) -> Self {
 		Self {
 			conn,
 			model: ConnectionModel::new(),
@@ -286,7 +288,7 @@ impl Connection<side::Server> {
 	///
 	/// The stream should be accepted by `quinn::Connection::accept_uni()`
 	/// from the same `QuinnConnection`.
-	pub async fn accept_uni_stream<R: StreamRx>(&self, mut recv: R) -> Result<Task<SendStream, R>, Error> {
+	pub async fn accept_uni_stream<R: StreamRx>(&self, mut recv: R) -> Result<Task<quinn_crate::SendStream, R>, Error> {
 		let header = match Header::async_unmarshal(&mut recv).await {
 			Ok(header) => header,
 			Err(err) => return Err(Error::UnmarshalUniStream(err)),
@@ -403,7 +405,7 @@ impl Authenticate {
 ///
 /// Generic over the QUIC send/receive stream types, allowing use with
 /// different QUIC implementations that implement `StreamTx`/`StreamRx`.
-pub struct Connect<S: StreamTx = SendStream, R: StreamRx = RecvStream> {
+pub struct Connect<S: StreamTx = quinn_crate::SendStream, R: StreamRx = quinn_crate::RecvStream> {
 	model:    Side<ConnectModel<model_side::Tx>, ConnectModel<model_side::Rx>>,
 	pub send: S,
 	pub recv: R,
@@ -430,7 +432,7 @@ impl<S: StreamTx, R: StreamRx> Connect<S, R> {
 	/// Immediately closes the `Connect` streams with the given error code.
 	/// Returns the result of closing the send and receive streams,
 	/// respectively.
-	pub fn reset(&mut self, error_code: VarInt) -> eyre::Result<()> {
+	pub fn reset(&mut self, error_code: quinn_crate::VarInt) -> eyre::Result<()> {
 		self.send.reset(error_code)?;
 		self.recv.stop(error_code)?;
 		Ok(())
@@ -440,7 +442,7 @@ impl<S: StreamTx, R: StreamRx> Connect<S, R> {
 	/// Rx: refuse accepting data
 	pub async fn finish(&mut self) -> eyre::Result<()> {
 		self.send.finish()?;
-		self.recv.stop(VarInt::from_u32(0))?;
+		self.recv.stop(quinn_crate::VarInt::from_u32(0))?;
 		Ok(())
 	}
 }
@@ -482,13 +484,13 @@ impl<S: StreamTx + Debug, R: StreamRx + Debug> Debug for Connect<S, R> {
 
 /// Source of a received `Packet` command.
 #[derive(Debug)]
-pub enum PacketSource<R: StreamRx = RecvStream> {
+pub enum PacketSource<R: StreamRx = quinn_crate::RecvStream> {
 	Quic(R),
 	Native(Bytes),
 }
 
 /// A received `Packet` command.
-pub struct Packet<R: StreamRx = RecvStream> {
+pub struct Packet<R: StreamRx = quinn_crate::RecvStream> {
 	model: PacketModel<model_side::Rx, Bytes>,
 	src:   PacketSource<R>,
 }
@@ -562,7 +564,7 @@ impl<R: StreamRx + Debug> Debug for Packet<R> {
 /// Type of tasks that can be received.
 #[non_exhaustive]
 #[derive(Debug)]
-pub enum Task<S: StreamTx = SendStream, R: StreamRx = RecvStream> {
+pub enum Task<S: StreamTx = quinn_crate::SendStream, R: StreamRx = quinn_crate::RecvStream> {
 	Authenticate(Authenticate),
 	Connect(Connect<S, R>),
 	Packet(Packet<R>),
@@ -571,7 +573,7 @@ pub enum Task<S: StreamTx = SendStream, R: StreamRx = RecvStream> {
 }
 
 #[derive(Debug)]
-struct KeyingMaterialExporter(QuinnConnection);
+struct KeyingMaterialExporter(quinn_crate::Connection);
 
 impl KeyingMaterialExporterImpl for KeyingMaterialExporter {
 	fn export_keying_material(&self, label: &[u8], context: &[u8]) -> [u8; 32] {
@@ -590,9 +592,9 @@ pub enum Error {
 	#[error(transparent)]
 	IoError(#[from] IoError),
 	#[error(transparent)]
-	Connection(#[from] ConnectionError),
+	Connection(#[from] quinn_crate::ConnectionError),
 	#[error(transparent)]
-	SendDatagram(#[from] SendDatagramError),
+	SendDatagram(#[from] quinn_crate::SendDatagramError),
 	#[error("expecting payload length {0} but got {1}")]
 	PayloadLength(usize, usize),
 	#[error("packet {1:#06x} on invalid udp session {0:#06x}")]
@@ -612,5 +614,5 @@ pub enum Error {
 	#[error("bad command `{0}` from datagram")]
 	BadCommandDatagram(&'static str, Bytes),
 	#[error(transparent)]
-	QuicWriteError(#[from] ::quinn::WriteError),
+	QuicWriteError(#[from] quinn_crate::WriteError),
 }

--- a/tuic-core/src/quinn_impl.rs
+++ b/tuic-core/src/quinn_impl.rs
@@ -9,13 +9,13 @@ use std::{
 use bytes::{BufMut, Bytes, BytesMut};
 use peekable::{buffer::Buffer, tokio::AsyncPeekable};
 pub use quinn_congestions::{self, bbr};
-#[allow(hidden_glob_reexports)]
 pub use quinn_crate::{Connection as QuinnConnection, *};
 use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, ReadBuf};
 use tracing::warn;
 use uuid::Uuid;
 
+#[allow(hidden_glob_reexports)]
 use self::side::Side;
 use crate::{
 	Address, Header, UnmarshalError,

--- a/tuic-core/src/quinn_impl.rs
+++ b/tuic-core/src/quinn_impl.rs
@@ -6,12 +6,11 @@ use std::{
 	time::Duration,
 };
 
-pub use quinn_crate::*;
-pub use quinn_crate::Connection as QuinnConnection;
-pub use quinn_congestions;
-pub use quinn_congestions::bbr;
 use bytes::{BufMut, Bytes, BytesMut};
 use peekable::{buffer::Buffer, tokio::AsyncPeekable};
+pub use quinn_congestions::{self, bbr};
+#[allow(hidden_glob_reexports)]
+pub use quinn_crate::{Connection as QuinnConnection, *};
 use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, ReadBuf};
 use tracing::warn;
@@ -45,7 +44,9 @@ pub trait StreamTx: tokio::io::AsyncWrite + futures_util::AsyncWrite + Unpin + S
 	/// Notify the peer that no more data will be written to this stream.
 	fn finish(&mut self) -> Result<(), quinn_crate::ClosedStream>;
 	/// Wait for the stream to be stopped or read to completion by the peer.
-	fn stopped(&mut self) -> impl std::future::Future<Output = Result<Option<quinn_crate::VarInt>, quinn_crate::StoppedError>> + Send;
+	fn stopped(
+		&mut self,
+	) -> impl std::future::Future<Output = Result<Option<quinn_crate::VarInt>, quinn_crate::StoppedError>> + Send;
 	/// Close the send stream immediately with the given error code.
 	fn reset(&mut self, error_code: quinn_crate::VarInt) -> Result<(), quinn_crate::ClosedStream>;
 }
@@ -61,7 +62,9 @@ impl StreamTx for quinn_crate::SendStream {
 		quinn_crate::SendStream::finish(self)
 	}
 
-	fn stopped(&mut self) -> impl std::future::Future<Output = Result<Option<quinn_crate::VarInt>, quinn_crate::StoppedError>> + Send {
+	fn stopped(
+		&mut self,
+	) -> impl std::future::Future<Output = Result<Option<quinn_crate::VarInt>, quinn_crate::StoppedError>> + Send {
 		quinn_crate::SendStream::stopped(self)
 	}
 

--- a/tuic-server/Cargo.toml
+++ b/tuic-server/Cargo.toml
@@ -13,8 +13,8 @@ repository.workspace = true
 
 [features]
 default = ["aws-lc-rs"]
-ring = ["tuic-core/ring", "rustls/ring", "rcgen/ring", "quinn/rustls-ring", "rustls-acme/ring"]
-aws-lc-rs = ["tuic-core/aws-lc-rs", "dep:aws-lc-rs", "rustls/aws-lc-rs", "rcgen/aws_lc_rs", "quinn/rustls-aws-lc-rs", "rustls-acme/aws-lc-rs"]
+ring = ["tuic-core/ring", "rustls/ring", "rcgen/ring", "rustls-acme/ring"]
+aws-lc-rs = ["tuic-core/aws-lc-rs", "dep:aws-lc-rs", "rustls/aws-lc-rs", "rcgen/aws_lc_rs", "rustls-acme/aws-lc-rs"]
 jemallocator = ["tikv-jemallocator"]
 
 [dependencies]
@@ -28,10 +28,6 @@ arc-swap = "1"
 uuid = { version = "1", default-features = false, features = ["serde", "std", "v4"] }
 moka = { version = "0.12", features = ["future"] }
 sha2 = "0.11"
-
-# QUIC
-quinn = { workspace = true, default-features = false, features = ["runtime-tokio", "qlog"] }
-quinn-congestions = { workspace = true }
 
 # TUIC
 tuic-core = { path = "../tuic-core", default-features = false, features = ["async_marshal", "marshal", "model"] }

--- a/tuic-server/src/camouflage.rs
+++ b/tuic-server/src/camouflage.rs
@@ -7,7 +7,7 @@ use axum::http::{
 use bytes::{Buf, Bytes};
 use futures_util::StreamExt;
 use h3::server;
-use quinn::Connection;
+use tuic_core::quinn::QuinnConnection;
 use reqwest::{Client, Method, Url};
 use tracing::{debug, info, warn};
 
@@ -18,7 +18,7 @@ const MAX_RESPONSE_BODY_SIZE: usize = 64 * 1024 * 1024;
 
 pub async fn handle(
 	ctx: Arc<AppContext>,
-	conn: Connection,
+	conn: QuinnConnection,
 	prefetched_uni: Option<crate::h3_quinn_compat::PeekableRecvStream>,
 	prefetched_bi: Option<crate::h3_quinn_compat::PrefetchedBiRecv>,
 ) -> eyre::Result<()> {

--- a/tuic-server/src/camouflage.rs
+++ b/tuic-server/src/camouflage.rs
@@ -7,9 +7,9 @@ use axum::http::{
 use bytes::{Buf, Bytes};
 use futures_util::StreamExt;
 use h3::server;
-use tuic_core::quinn::QuinnConnection;
 use reqwest::{Client, Method, Url};
 use tracing::{debug, info, warn};
+use tuic_core::quinn::QuinnConnection;
 
 use crate::{AppContext, config::CamouflageConfig};
 

--- a/tuic-server/src/compat.rs
+++ b/tuic-server/src/compat.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use quinn::Connection as QuinnConnection;
+use tuic_core::quinn::QuinnConnection;
 
 #[derive(Clone)]
 pub struct QuicClient(QuinnConnection);

--- a/tuic-server/src/connection/handle_stream.rs
+++ b/tuic-server/src/connection/handle_stream.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::Ordering;
 
 use bytes::Bytes;
-use quinn::VarInt;
+use tuic_core::quinn::VarInt;
 use register_count::Register;
 use tokio::time;
 use tracing::{debug, warn};

--- a/tuic-server/src/connection/handle_stream.rs
+++ b/tuic-server/src/connection/handle_stream.rs
@@ -1,11 +1,10 @@
 use std::sync::atomic::Ordering;
 
 use bytes::Bytes;
-use tuic_core::quinn::VarInt;
 use register_count::Register;
 use tokio::time;
 use tracing::{debug, warn};
-use tuic_core::quinn::{StreamRx, StreamTx, Task};
+use tuic_core::quinn::{StreamRx, StreamTx, Task, VarInt};
 
 use super::Connection;
 use crate::{error::Error, utils::UdpRelayMode};

--- a/tuic-server/src/connection/handle_task.rs
+++ b/tuic-server/src/connection/handle_task.rs
@@ -13,8 +13,8 @@ use tokio::{
 use tracing::{info, warn};
 use tuic_core::{
 	Address, is_private_ip,
-	quinn::{Authenticate, Connect, Packet, StreamRx, StreamTx},
 };
+use tuic_core::quinn::{Authenticate, Connect, Packet, StreamRx, StreamTx};
 
 use super::{Connection, ERROR_CODE, UdpSession};
 use crate::{

--- a/tuic-server/src/connection/handle_task.rs
+++ b/tuic-server/src/connection/handle_task.rs
@@ -13,8 +13,8 @@ use tokio::{
 use tracing::{info, warn};
 use tuic_core::{
 	Address, is_private_ip,
+	quinn::{Authenticate, Connect, Packet, StreamRx, StreamTx},
 };
-use tuic_core::quinn::{Authenticate, Connect, Packet, StreamRx, StreamTx};
 
 use super::{Connection, ERROR_CODE, UdpSession};
 use crate::{

--- a/tuic-server/src/connection/mod.rs
+++ b/tuic-server/src/connection/mod.rs
@@ -7,12 +7,11 @@ use arc_swap::ArcSwap;
 use bytes::Bytes;
 use moka::future::Cache;
 use peekable::tokio::AsyncPeekExt;
-use tuic_core::quinn::{Connecting, QuinnConnection, VarInt};
 use register_count::Counter;
 use smallvec::SmallVec;
 use tokio::time;
 use tracing::{Instrument, Span, debug, info, info_span, warn};
-use tuic_core::quinn::{Authenticate, Connection as Model, side};
+use tuic_core::quinn::{Authenticate, Connecting, Connection as Model, QuinnConnection, VarInt, side};
 
 use self::{authenticated::Authenticated, udp_session::UdpSession};
 use crate::{AppContext, camouflage, error::Error, restful, utils::UdpRelayMode};
@@ -291,7 +290,11 @@ impl Connection {
 		}
 	}
 
-	async fn classify_recv_stream(&self, recv: tuic_core::quinn::RecvStream, timeout: Duration) -> Result<ClassifiedRecvStream, Error> {
+	async fn classify_recv_stream(
+		&self,
+		recv: tuic_core::quinn::RecvStream,
+		timeout: Duration,
+	) -> Result<ClassifiedRecvStream, Error> {
 		let mut recv = recv.peekable_with_buffer::<SmallVec<[u8; 4]>>();
 		let mut prefix = [0u8; 2];
 		let read = time::timeout(timeout, recv.peek_exact(&mut prefix))

--- a/tuic-server/src/connection/mod.rs
+++ b/tuic-server/src/connection/mod.rs
@@ -7,7 +7,7 @@ use arc_swap::ArcSwap;
 use bytes::Bytes;
 use moka::future::Cache;
 use peekable::tokio::AsyncPeekExt;
-use quinn::{Connecting, Connection as QuinnConnection, VarInt};
+use tuic_core::quinn::{Connecting, QuinnConnection, VarInt};
 use register_count::Counter;
 use smallvec::SmallVec;
 use tokio::time;
@@ -34,8 +34,8 @@ enum H3Dispatch {
 }
 
 enum FirstEvent {
-	Uni(quinn::RecvStream),
-	Bi(quinn::SendStream, quinn::RecvStream),
+	Uni(tuic_core::quinn::RecvStream),
+	Bi(tuic_core::quinn::SendStream, tuic_core::quinn::RecvStream),
 	Datagram(Bytes),
 }
 
@@ -47,7 +47,7 @@ enum ClassifiedRecvStream {
 enum PrefetchedFirstEventTuic {
 	Uni(crate::h3_quinn_compat::PeekableRecvStream),
 	Bi {
-		send: quinn::SendStream,
+		send: tuic_core::quinn::SendStream,
 		recv: crate::h3_quinn_compat::PeekableRecvStream,
 	},
 	Datagram(Bytes),
@@ -291,7 +291,7 @@ impl Connection {
 		}
 	}
 
-	async fn classify_recv_stream(&self, recv: quinn::RecvStream, timeout: Duration) -> Result<ClassifiedRecvStream, Error> {
+	async fn classify_recv_stream(&self, recv: tuic_core::quinn::RecvStream, timeout: Duration) -> Result<ClassifiedRecvStream, Error> {
 		let mut recv = recv.peekable_with_buffer::<SmallVec<[u8; 4]>>();
 		let mut prefix = [0u8; 2];
 		let read = time::timeout(timeout, recv.peek_exact(&mut prefix))

--- a/tuic-server/src/error.rs
+++ b/tuic-server/src/error.rs
@@ -1,9 +1,8 @@
 use std::{io::Error as IoError, net::SocketAddr};
 
-use tuic_core::quinn::ConnectionError;
 use rustls::Error as RustlsError;
 use thiserror::Error;
-use tuic_core::quinn::Error as ModelError;
+use tuic_core::quinn::{ConnectionError, Error as ModelError};
 use uuid::Uuid;
 
 #[derive(Debug, Error)]

--- a/tuic-server/src/error.rs
+++ b/tuic-server/src/error.rs
@@ -1,6 +1,6 @@
 use std::{io::Error as IoError, net::SocketAddr};
 
-use quinn::ConnectionError;
+use tuic_core::quinn::ConnectionError;
 use rustls::Error as RustlsError;
 use thiserror::Error;
 use tuic_core::quinn::Error as ModelError;

--- a/tuic-server/src/h3_quinn_compat.rs
+++ b/tuic-server/src/h3_quinn_compat.rs
@@ -17,20 +17,20 @@ use h3::{
 	quic::{self, ConnectionErrorIncoming, StreamErrorIncoming, StreamId, WriteBuf},
 };
 use peekable::tokio::AsyncPeekable;
-use quinn::{AcceptBi, AcceptUni, OpenBi, OpenUni, ReadError, VarInt};
+use tuic_core::quinn::{AcceptBi, AcceptUni, OpenBi, OpenUni, ReadError, VarInt};
 use tokio_util::sync::ReusableBoxFuture;
 
 type BoxStreamSync<'a, T> = Pin<Box<dyn Stream<Item = T> + Sync + Send + 'a>>;
 
-pub type PeekableRecvStream = AsyncPeekable<quinn::RecvStream, smallvec::SmallVec<[u8; 4]>>;
+pub type PeekableRecvStream = AsyncPeekable<tuic_core::quinn::RecvStream, smallvec::SmallVec<[u8; 4]>>;
 
 pub struct PrefetchedBiRecv {
-	pub send: quinn::SendStream,
+	pub send: tuic_core::quinn::SendStream,
 	pub recv: PeekableRecvStream,
 }
 
 pub struct Connection {
-	conn:           quinn::Connection,
+	conn:           tuic_core::quinn::QuinnConnection,
 	incoming_bi:    BoxStreamSync<'static, <AcceptBi<'static> as Future>::Output>,
 	opening_bi:     Option<BoxStreamSync<'static, <OpenBi<'static> as Future>::Output>>,
 	incoming_uni:   BoxStreamSync<'static, <AcceptUni<'static> as Future>::Output>,
@@ -40,7 +40,7 @@ pub struct Connection {
 }
 
 impl Connection {
-	pub fn new(conn: quinn::Connection) -> Self {
+	pub fn new(conn: tuic_core::quinn::QuinnConnection) -> Self {
 		Self {
 			conn:           conn.clone(),
 			incoming_bi:    Box::pin(stream::unfold(conn.clone(), |conn| async {
@@ -57,7 +57,7 @@ impl Connection {
 	}
 
 	pub fn new_with_prefetched(
-		conn: quinn::Connection,
+		conn: tuic_core::quinn::QuinnConnection,
 		prefetched_uni: Option<PeekableRecvStream>,
 		prefetched_bi: Option<PrefetchedBiRecv>,
 	) -> Self {
@@ -112,18 +112,18 @@ where
 	}
 }
 
-fn convert_connection_error(err: quinn::ConnectionError) -> ConnectionErrorIncoming {
+fn convert_connection_error(err: tuic_core::quinn::ConnectionError) -> ConnectionErrorIncoming {
 	match err {
-		quinn::ConnectionError::ApplicationClosed(close) => ConnectionErrorIncoming::ApplicationClose {
+		tuic_core::quinn::ConnectionError::ApplicationClosed(close) => ConnectionErrorIncoming::ApplicationClose {
 			error_code: close.error_code.into(),
 		},
-		quinn::ConnectionError::TimedOut => ConnectionErrorIncoming::Timeout,
-		error @ quinn::ConnectionError::VersionMismatch
-		| error @ quinn::ConnectionError::TransportError(_)
-		| error @ quinn::ConnectionError::ConnectionClosed(_)
-		| error @ quinn::ConnectionError::Reset
-		| error @ quinn::ConnectionError::LocallyClosed
-		| error @ quinn::ConnectionError::CidsExhausted => ConnectionErrorIncoming::Undefined(Arc::new(error)),
+		tuic_core::quinn::ConnectionError::TimedOut => ConnectionErrorIncoming::Timeout,
+		error @ tuic_core::quinn::ConnectionError::VersionMismatch
+		| error @ tuic_core::quinn::ConnectionError::TransportError(_)
+		| error @ tuic_core::quinn::ConnectionError::ConnectionClosed(_)
+		| error @ tuic_core::quinn::ConnectionError::Reset
+		| error @ tuic_core::quinn::ConnectionError::LocallyClosed
+		| error @ tuic_core::quinn::ConnectionError::CidsExhausted => ConnectionErrorIncoming::Undefined(Arc::new(error)),
 	}
 }
 
@@ -175,7 +175,7 @@ where
 }
 
 pub struct OpenStreams {
-	conn:        quinn::Connection,
+	conn:        tuic_core::quinn::QuinnConnection,
 	opening_bi:  Option<BoxStreamSync<'static, <OpenBi<'static> as Future>::Output>>,
 	opening_uni: Option<BoxStreamSync<'static, <OpenUni<'static> as Future>::Output>>,
 }
@@ -302,10 +302,10 @@ pub struct RecvStream {
 	read_chunk_fut:    ReadChunkFuture,
 }
 
-type ReadChunkFuture = ReusableBoxFuture<'static, (PeekableRecvStream, Result<Option<quinn::Chunk>, quinn::ReadError>)>;
+type ReadChunkFuture = ReusableBoxFuture<'static, (PeekableRecvStream, Result<Option<tuic_core::quinn::Chunk>, tuic_core::quinn::ReadError>)>;
 
 impl RecvStream {
-	fn new(stream: quinn::RecvStream) -> Self {
+	fn new(stream: tuic_core::quinn::RecvStream) -> Self {
 		let num: u64 = stream.id().into();
 		Self::new_inner(AsyncPeekable::with_buffer(stream), num)
 	}
@@ -384,27 +384,27 @@ fn convert_read_error_to_stream_error(error: ReadError) -> StreamErrorIncoming {
 	}
 }
 
-fn convert_write_error_to_stream_error(error: quinn::WriteError) -> StreamErrorIncoming {
+fn convert_write_error_to_stream_error(error: tuic_core::quinn::WriteError) -> StreamErrorIncoming {
 	match error {
-		quinn::WriteError::Stopped(var_int) => StreamErrorIncoming::StreamTerminated {
+		tuic_core::quinn::WriteError::Stopped(var_int) => StreamErrorIncoming::StreamTerminated {
 			error_code: var_int.into_inner(),
 		},
-		quinn::WriteError::ConnectionLost(connection_error) => StreamErrorIncoming::ConnectionErrorIncoming {
+		tuic_core::quinn::WriteError::ConnectionLost(connection_error) => StreamErrorIncoming::ConnectionErrorIncoming {
 			connection_error: convert_connection_error(connection_error),
 		},
-		error @ quinn::WriteError::ClosedStream | error @ quinn::WriteError::ZeroRttRejected => {
+		error @ tuic_core::quinn::WriteError::ClosedStream | error @ tuic_core::quinn::WriteError::ZeroRttRejected => {
 			StreamErrorIncoming::Unknown(Box::new(error))
 		}
 	}
 }
 
 pub struct SendStream<B: Buf> {
-	stream:  quinn::SendStream,
+	stream:  tuic_core::quinn::SendStream,
 	writing: Option<WriteBuf<B>>,
 }
 
 impl<B: Buf> SendStream<B> {
-	fn new(stream: quinn::SendStream) -> Self {
+	fn new(stream: tuic_core::quinn::SendStream) -> Self {
 		Self { stream, writing: None }
 	}
 }

--- a/tuic-server/src/h3_quinn_compat.rs
+++ b/tuic-server/src/h3_quinn_compat.rs
@@ -17,8 +17,8 @@ use h3::{
 	quic::{self, ConnectionErrorIncoming, StreamErrorIncoming, StreamId, WriteBuf},
 };
 use peekable::tokio::AsyncPeekable;
-use tuic_core::quinn::{AcceptBi, AcceptUni, OpenBi, OpenUni, ReadError, VarInt};
 use tokio_util::sync::ReusableBoxFuture;
+use tuic_core::quinn::{AcceptBi, AcceptUni, OpenBi, OpenUni, ReadError, VarInt};
 
 type BoxStreamSync<'a, T> = Pin<Box<dyn Stream<Item = T> + Sync + Send + 'a>>;
 
@@ -302,7 +302,13 @@ pub struct RecvStream {
 	read_chunk_fut:    ReadChunkFuture,
 }
 
-type ReadChunkFuture = ReusableBoxFuture<'static, (PeekableRecvStream, Result<Option<tuic_core::quinn::Chunk>, tuic_core::quinn::ReadError>)>;
+type ReadChunkFuture = ReusableBoxFuture<
+	'static,
+	(
+		PeekableRecvStream,
+		Result<Option<tuic_core::quinn::Chunk>, tuic_core::quinn::ReadError>,
+	),
+>;
 
 impl RecvStream {
 	fn new(stream: tuic_core::quinn::RecvStream) -> Self {

--- a/tuic-server/src/restful.rs
+++ b/tuic-server/src/restful.rs
@@ -15,9 +15,9 @@ use axum_extra::{
 	headers::{Authorization, authorization::Bearer},
 };
 use moka::future::Cache;
-use tuic_core::quinn::{QuinnConnection, VarInt};
 use serde_json::json;
 use tracing::warn;
+use tuic_core::quinn::{QuinnConnection, VarInt};
 use uuid::Uuid;
 
 use crate::AppContext;

--- a/tuic-server/src/restful.rs
+++ b/tuic-server/src/restful.rs
@@ -15,7 +15,7 @@ use axum_extra::{
 	headers::{Authorization, authorization::Bearer},
 };
 use moka::future::Cache;
-use quinn::{Connection as QuinnConnection, VarInt};
+use tuic_core::quinn::{QuinnConnection, VarInt};
 use serde_json::json;
 use tracing::warn;
 use uuid::Uuid;

--- a/tuic-server/src/server.rs
+++ b/tuic-server/src/server.rs
@@ -5,18 +5,18 @@ use std::{
 };
 
 use eyre::Context;
-use tuic_core::quinn::{
-	Endpoint, EndpointConfig, IdleTimeout, ServerConfig, TokioRuntime, TransportConfig, VarInt,
-	congestion::{Bbr3Config, CubicConfig, NewRenoConfig},
-	crypto::rustls::QuicServerConfig,
-	bbr::BbrConfig,
-};
 use rustls::{
 	ServerConfig as RustlsServerConfig,
 	pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer},
 };
 use socket2::{Domain, Protocol, SockAddr, Socket, Type};
 use tracing::{debug, info, warn};
+use tuic_core::quinn::{
+	Endpoint, EndpointConfig, IdleTimeout, ServerConfig, TokioRuntime, TransportConfig, VarInt,
+	bbr::BbrConfig,
+	congestion::{Bbr3Config, CubicConfig, NewRenoConfig},
+	crypto::rustls::QuicServerConfig,
+};
 
 use crate::{
 	AppContext,

--- a/tuic-server/src/server.rs
+++ b/tuic-server/src/server.rs
@@ -5,12 +5,12 @@ use std::{
 };
 
 use eyre::Context;
-use quinn::{
+use tuic_core::quinn::{
 	Endpoint, EndpointConfig, IdleTimeout, ServerConfig, TokioRuntime, TransportConfig, VarInt,
 	congestion::{Bbr3Config, CubicConfig, NewRenoConfig},
 	crypto::rustls::QuicServerConfig,
+	bbr::BbrConfig,
 };
-use quinn_congestions::bbr::BbrConfig;
 use rustls::{
 	ServerConfig as RustlsServerConfig,
 	pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer},


### PR DESCRIPTION
Remove direct quinn dependency from tuic-client and tuic-server. Both sub-crates now use tuic-core's re-exported quinn via `tuic_core::quinn`.

- Rename `quinn.rs` → `quinn_impl.rs` to avoid Rust 2024 edition naming conflict
- Re-export `quinn_congestions::bbr` at `tuic_core::quinn::bbr`
- Forward TLS/rustls feature flags through tuic-core

Assisted-by: OpenClaw:deepseek-v4-flash