### PR TITLE
ci: enable sccache for cross-rs containers via .cross/Dockerfile

### DIFF
--- a/.cross/Dockerfile
+++ b/.cross/Dockerfile
@@ -1,0 +1,15 @@
+ARG CROSS_BASE_IMAGE
+FROM $CROSS_BASE_IMAGE
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends clang llvm && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV CC=clang
+ENV CXX=clang++
+ENV AR=llvm-ar
+
+# sccache: distributed compilation cache via host TCP server
+ARG SCCACHE_VERSION=0.15.0
+RUN curl -LSfs https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz \
+    | tar xzf - -C /usr/local/bin --strip-components=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   build:
     name: Build
-    uses: rust-proxy/workflows/.github/workflows/rust-build.yml@main
+    uses: rust-proxy/workflows/.github/workflows/rust-build.yml@v1.0.22
     secrets:
       sentry-dsn: ${{ secrets.SENTRY_DSN }}
     with:
@@ -34,20 +34,21 @@ jobs:
       target-config-file: ".github/target.toml"
       rustflags: ""
       enable-tmate: false
+      enable-sccache: true
       only-clippy-tests-on-pr: false
 
   release:
     name: Release
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))
     needs: [build]
-    uses: rust-proxy/workflows/.github/workflows/release-publish.yml@main
+    uses: rust-proxy/workflows/.github/workflows/release-publish.yml@v1.0.22
     with:
       cliff-config: '.github/cliff.toml'
 
   docker:
     name: Docker
     needs: [build]
-    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@main
+    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.22
     with:
       docker-file: '.github/Dockerfile'
       image-name: 'tuic-server'

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,8 +1,23 @@
-[build]
+# Use clang as the C/C++ compiler to avoid the aws-lc-sys GCC memcmp bug
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189
+# The custom Dockerfile installs clang/llvm and sets CC=clang, CXX=clang++, AR=llvm-ar
+# sccache is also baked into the image for distributed compilation via host TCP server
+
+[build.dockerfile]
+file = ".cross/Dockerfile"
 
 [build.env]
-volumes = ["/var/run/docker.sock=/var/run/docker.sock", "/tmp=/tmp"] # Docker in docker
-passthrough = ["RUSTFLAGS", "RUST_LOG", "CARGO_DOCKER_TEST", "RUSTC_BOOTSTRAP"]
+volumes = [
+    "/tmp=/tmp",
+]
+passthrough = [
+    "RUSTFLAGS",
+    "RUST_LOG",
+    "RUSTC_BOOTSTRAP",
+    "RUSTC_WRAPPER",
+    "SCCACHE_DIR",
+    "SCCACHE_SERVER_PORT",
+]
 
 [target.mips-unknown-linux-musl]
 image = "ghcr.io/cross-rs/mips-unknown-linux-musl:edge"


### PR DESCRIPTION
### Summary

Enable sccache distributed compilation caching inside cross-rs containers by baking sccache into a custom cross image (`.cross/Dockerfile`). Cross containers connect to the host's sccache TCP server via `--network host`.

### Changes

**`.cross/Dockerfile`**
- Installs `sccache` binary (v0.15.0) directly in the image
- Installs `clang`/`llvm` as C/C++ compiler (fixes `aws-lc-sys` GCC memcmp bug, `CC=clang`, `CXX=clang++`, `AR=llvm-ar`)

**`Cross.toml`**
- `[build.dockerfile]` → points to `.cross/Dockerfile`
- Passthrough: `RUSTC_WRAPPER`, `SCCACHE_DIR`, `SCCACHE_SERVER_PORT`, `RUSTFLAGS`, `RUST_LOG`, `RUSTC_BOOTSTRAP`
- Volume: `/tmp=/tmp` for shared temp access

**Workflow** (`rust-proxy/workflows@v1.0.22`)
- Host runs sccache server via `actions/cache` + local disk mode
- Cross containers reach host via `CROSS_CONTAINER_OPTS=--network host`

### Why

Previously sccache was installed via `pre-build` in `Cross.toml` (downloaded on every run). This moves the installation to the Docker image once, eliminating the per-run download overhead.

### CI Status

All 20 build targets passed ✅