### PR TITLE
chore: bump workflows to v1.0.35, fix sccache dir & cross-rs integration

### DIFF
--- a/.cross/Dockerfile
+++ b/.cross/Dockerfile
@@ -14,5 +14,5 @@ ARG SCCACHE_VERSION=0.15.0
 RUN curl -LSfs https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz \
     | tar xzf - -C /usr/local/bin --strip-components=1
 
-# Connect to host sccache server via network host mode
-ENV SCCACHE_ENDPOINT=tcp://127.0.0.1:14266
+# Container-local sccache server port (isolated from host on 4226)
+ENV SCCACHE_SERVER_PORT=14266

--- a/.cross/Dockerfile
+++ b/.cross/Dockerfile
@@ -13,3 +13,6 @@ ENV AR=llvm-ar
 ARG SCCACHE_VERSION=0.15.0
 RUN curl -LSfs https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz \
     | tar xzf - -C /usr/local/bin --strip-components=1
+
+# Connect to host sccache server via network host mode
+ENV SCCACHE_ENDPOINT=tcp://127.0.0.1:14266

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   build:
     name: Build
-    uses: rust-proxy/workflows/.github/workflows/rust-build.yml@v1.0.30
+    uses: rust-proxy/workflows/.github/workflows/rust-build.yml@v1.0.31
     secrets:
       sentry-dsn: ${{ secrets.SENTRY_DSN }}
     with:
@@ -41,14 +41,14 @@ jobs:
     name: Release
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))
     needs: [build]
-    uses: rust-proxy/workflows/.github/workflows/release-publish.yml@v1.0.30
+    uses: rust-proxy/workflows/.github/workflows/release-publish.yml@v1.0.31
     with:
       cliff-config: '.github/cliff.toml'
 
   docker:
     name: Docker
     needs: [build]
-    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.30
+    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.31
     with:
       docker-file: '.github/Dockerfile'
       image-name: 'tuic-server'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   build:
     name: Build
-    uses: rust-proxy/workflows/.github/workflows/rust-build.yml@v1.0.26
+    uses: rust-proxy/workflows/.github/workflows/rust-build.yml@v1.0.27
     secrets:
       sentry-dsn: ${{ secrets.SENTRY_DSN }}
     with:
@@ -41,14 +41,14 @@ jobs:
     name: Release
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))
     needs: [build]
-    uses: rust-proxy/workflows/.github/workflows/release-publish.yml@v1.0.26
+    uses: rust-proxy/workflows/.github/workflows/release-publish.yml@v1.0.27
     with:
       cliff-config: '.github/cliff.toml'
 
   docker:
     name: Docker
     needs: [build]
-    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.26
+    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.27
     with:
       docker-file: '.github/Dockerfile'
       image-name: 'tuic-server'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   build:
     name: Build
-    uses: rust-proxy/workflows/.github/workflows/rust-build.yml@v1.0.34
+    uses: rust-proxy/workflows/.github/workflows/rust-build.yml@v1.0.35
     secrets:
       sentry-dsn: ${{ secrets.SENTRY_DSN }}
     with:
@@ -41,14 +41,14 @@ jobs:
     name: Release
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))
     needs: [build]
-    uses: rust-proxy/workflows/.github/workflows/release-publish.yml@v1.0.34
+    uses: rust-proxy/workflows/.github/workflows/release-publish.yml@v1.0.35
     with:
       cliff-config: '.github/cliff.toml'
 
   docker:
     name: Docker
     needs: [build]
-    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.34
+    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.35
     with:
       docker-file: '.github/Dockerfile'
       image-name: 'tuic-server'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
-﻿name: CI
+name: CI
+
 on:
   push:
     tags: ["v*"]
@@ -6,20 +7,25 @@ on:
   pull_request:
     branches: ["main"]
   workflow_dispatch:
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+
 defaults:
   run:
     shell: bash
+
 env:
   RUST_LOG: "tuic_server=TRACE,tuic_client=TRACE"
   RUST_TOOLCHAIN: "stable"
   RUSTC_BOOTSTRAP: "1"
   SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+
 jobs:
   build:
     name: Build
+    uses: rust-proxy/workflows/.github/workflows/rust-build.yml@v1.0.24
     secrets:
       sentry-dsn: ${{ secrets.SENTRY_DSN }}
     with:
@@ -30,17 +36,19 @@ jobs:
       enable-tmate: false
       enable-sccache: true
       only-clippy-tests-on-pr: false
+
   release:
     name: Release
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))
     needs: [build]
-    uses: rust-proxy/workflows/.github/workflows/release-publish.yml@v1.0.23
+    uses: rust-proxy/workflows/.github/workflows/release-publish.yml@v1.0.24
     with:
       cliff-config: '.github/cliff.toml'
+
   docker:
     name: Docker
     needs: [build]
-    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.23
+    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.24
     with:
       docker-file: '.github/Dockerfile'
       image-name: 'tuic-server'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   build:
     name: Build
-    uses: rust-proxy/workflows/.github/workflows/rust-build.yml@v1.0.24
+    uses: rust-proxy/workflows/.github/workflows/rust-build.yml@v1.0.25
     secrets:
       sentry-dsn: ${{ secrets.SENTRY_DSN }}
     with:
@@ -41,14 +41,14 @@ jobs:
     name: Release
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))
     needs: [build]
-    uses: rust-proxy/workflows/.github/workflows/release-publish.yml@v1.0.24
+    uses: rust-proxy/workflows/.github/workflows/release-publish.yml@v1.0.25
     with:
       cliff-config: '.github/cliff.toml'
 
   docker:
     name: Docker
     needs: [build]
-    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.24
+    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.25
     with:
       docker-file: '.github/Dockerfile'
       image-name: 'tuic-server'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   build:
     name: Build
-    uses: rust-proxy/workflows/.github/workflows/rust-build.yml@v1.0.28
+    uses: rust-proxy/workflows/.github/workflows/rust-build.yml@v1.0.29
     secrets:
       sentry-dsn: ${{ secrets.SENTRY_DSN }}
     with:
@@ -41,14 +41,14 @@ jobs:
     name: Release
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))
     needs: [build]
-    uses: rust-proxy/workflows/.github/workflows/release-publish.yml@v1.0.28
+    uses: rust-proxy/workflows/.github/workflows/release-publish.yml@v1.0.29
     with:
       cliff-config: '.github/cliff.toml'
 
   docker:
     name: Docker
     needs: [build]
-    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.28
+    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.29
     with:
       docker-file: '.github/Dockerfile'
       image-name: 'tuic-server'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   build:
     name: Build
-    uses: rust-proxy/workflows/.github/workflows/rust-build.yml@v1.0.33
+    uses: rust-proxy/workflows/.github/workflows/rust-build.yml@v1.0.34
     secrets:
       sentry-dsn: ${{ secrets.SENTRY_DSN }}
     with:
@@ -41,14 +41,14 @@ jobs:
     name: Release
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))
     needs: [build]
-    uses: rust-proxy/workflows/.github/workflows/release-publish.yml@v1.0.33
+    uses: rust-proxy/workflows/.github/workflows/release-publish.yml@v1.0.34
     with:
       cliff-config: '.github/cliff.toml'
 
   docker:
     name: Docker
     needs: [build]
-    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.33
+    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.34
     with:
       docker-file: '.github/Dockerfile'
       image-name: 'tuic-server'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   build:
     name: Build
-    uses: rust-proxy/workflows/.github/workflows/rust-build.yml@v1.0.25
+    uses: rust-proxy/workflows/.github/workflows/rust-build.yml@v1.0.26
     secrets:
       sentry-dsn: ${{ secrets.SENTRY_DSN }}
     with:
@@ -41,14 +41,14 @@ jobs:
     name: Release
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))
     needs: [build]
-    uses: rust-proxy/workflows/.github/workflows/release-publish.yml@v1.0.25
+    uses: rust-proxy/workflows/.github/workflows/release-publish.yml@v1.0.26
     with:
       cliff-config: '.github/cliff.toml'
 
   docker:
     name: Docker
     needs: [build]
-    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.25
+    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.26
     with:
       docker-file: '.github/Dockerfile'
       image-name: 'tuic-server'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   build:
     name: Build
-    uses: rust-proxy/workflows/.github/workflows/rust-build.yml@v1.0.31
+    uses: rust-proxy/workflows/.github/workflows/rust-build.yml@v1.0.32
     secrets:
       sentry-dsn: ${{ secrets.SENTRY_DSN }}
     with:
@@ -41,14 +41,14 @@ jobs:
     name: Release
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))
     needs: [build]
-    uses: rust-proxy/workflows/.github/workflows/release-publish.yml@v1.0.31
+    uses: rust-proxy/workflows/.github/workflows/release-publish.yml@v1.0.32
     with:
       cliff-config: '.github/cliff.toml'
 
   docker:
     name: Docker
     needs: [build]
-    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.31
+    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.32
     with:
       docker-file: '.github/Dockerfile'
       image-name: 'tuic-server'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   build:
     name: Build
-    uses: rust-proxy/workflows/.github/workflows/rust-build.yml@v1.0.32
+    uses: rust-proxy/workflows/.github/workflows/rust-build.yml@v1.0.33
     secrets:
       sentry-dsn: ${{ secrets.SENTRY_DSN }}
     with:
@@ -41,14 +41,14 @@ jobs:
     name: Release
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))
     needs: [build]
-    uses: rust-proxy/workflows/.github/workflows/release-publish.yml@v1.0.32
+    uses: rust-proxy/workflows/.github/workflows/release-publish.yml@v1.0.33
     with:
       cliff-config: '.github/cliff.toml'
 
   docker:
     name: Docker
     needs: [build]
-    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.32
+    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.33
     with:
       docker-file: '.github/Dockerfile'
       image-name: 'tuic-server'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   build:
     name: Build
-    uses: rust-proxy/workflows/.github/workflows/rust-build.yml@v1.0.27
+    uses: rust-proxy/workflows/.github/workflows/rust-build.yml@v1.0.28
     secrets:
       sentry-dsn: ${{ secrets.SENTRY_DSN }}
     with:
@@ -41,14 +41,14 @@ jobs:
     name: Release
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))
     needs: [build]
-    uses: rust-proxy/workflows/.github/workflows/release-publish.yml@v1.0.27
+    uses: rust-proxy/workflows/.github/workflows/release-publish.yml@v1.0.28
     with:
       cliff-config: '.github/cliff.toml'
 
   docker:
     name: Docker
     needs: [build]
-    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.27
+    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.28
     with:
       docker-file: '.github/Dockerfile'
       image-name: 'tuic-server'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
 ﻿name: CI
-
 on:
   push:
     tags: ["v*"]
@@ -7,25 +6,20 @@ on:
   pull_request:
     branches: ["main"]
   workflow_dispatch:
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
-
 defaults:
   run:
     shell: bash
-
 env:
   RUST_LOG: "tuic_server=TRACE,tuic_client=TRACE"
   RUST_TOOLCHAIN: "stable"
   RUSTC_BOOTSTRAP: "1"
   SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-
 jobs:
   build:
     name: Build
-    uses: rust-proxy/workflows/.github/workflows/rust-build.yml@v1.0.23
     secrets:
       sentry-dsn: ${{ secrets.SENTRY_DSN }}
     with:
@@ -36,7 +30,6 @@ jobs:
       enable-tmate: false
       enable-sccache: true
       only-clippy-tests-on-pr: false
-
   release:
     name: Release
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))
@@ -44,7 +37,6 @@ jobs:
     uses: rust-proxy/workflows/.github/workflows/release-publish.yml@v1.0.23
     with:
       cliff-config: '.github/cliff.toml'
-
   docker:
     name: Docker
     needs: [build]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   build:
     name: Build
-    uses: rust-proxy/workflows/.github/workflows/rust-build.yml@v1.0.29
+    uses: rust-proxy/workflows/.github/workflows/rust-build.yml@v1.0.30
     secrets:
       sentry-dsn: ${{ secrets.SENTRY_DSN }}
     with:
@@ -41,14 +41,14 @@ jobs:
     name: Release
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))
     needs: [build]
-    uses: rust-proxy/workflows/.github/workflows/release-publish.yml@v1.0.29
+    uses: rust-proxy/workflows/.github/workflows/release-publish.yml@v1.0.30
     with:
       cliff-config: '.github/cliff.toml'
 
   docker:
     name: Docker
     needs: [build]
-    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.29
+    uses: rust-proxy/workflows/.github/workflows/docker-publish.yml@v1.0.30
     with:
       docker-file: '.github/Dockerfile'
       image-name: 'tuic-server'

--- a/Cross.toml
+++ b/Cross.toml
@@ -17,7 +17,6 @@ passthrough = [
     "RUSTC_BOOTSTRAP",
     "RUSTC_WRAPPER",
     "SCCACHE_DIR",
-    "SCCACHE_SERVER_PORT",
 ]
 
 [target.mips-unknown-linux-musl]

--- a/Cross.toml
+++ b/Cross.toml
@@ -9,7 +9,6 @@ file = ".cross/Dockerfile"
 [build.env]
 volumes = [
     "/var/run/docker.sock=/var/run/docker.sock",
-    "/tmp=/tmp",
 ]
 passthrough = [
     "RUSTFLAGS",

--- a/Cross.toml
+++ b/Cross.toml
@@ -8,6 +8,7 @@ file = ".cross/Dockerfile"
 
 [build.env]
 volumes = [
+    "/tmp=/tmp",
     "/var/run/docker.sock=/var/run/docker.sock",
 ]
 passthrough = [

--- a/Cross.toml
+++ b/Cross.toml
@@ -8,6 +8,7 @@ file = ".cross/Dockerfile"
 
 [build.env]
 volumes = [
+    "/var/run/docker.sock=/var/run/docker.sock",
     "/tmp=/tmp",
 ]
 passthrough = [


### PR DESCRIPTION
### Changes

Update `rust-proxy/workflows` tag from `v1.0.23` → `v1.0.35`.

**sccache fixes:**
- sccache dir: Linux → `/tmp/sccache` (shared with cross containers via `/tmp` volume), Windows → `%USERPROFILE%/.sccache`, macOS → `/home/ihsin/.sccache`
- Path determined via dedicated step + step output (avoids GHA expression `env.HOME` issue)
- Fixed `export SCCACHE_DIR` — was bash local var, server started with default dir
- `CROSS_CONTAINER_OPTS=--network host` for cross containers
- Container sccache isolation via port mismatch: host server on `4226`, Dockerfile declares `SCCACHE_SERVER_PORT=14266` (connection refused → falls back to local compilation)
- Removed `SCCACHE_ENDPOINT` from host env

**Cross.toml:**
- Restore `/tmp=/tmp` volume mount
- Passthrough: `RUSTC_WRAPPER`, `SCCACHE_DIR`, `RUSTFLAGS`, `RUST_LOG`, `RUSTC_BOOTSTRAP`

**.cross/Dockerfile:**
- sccache port declaration: `ENV SCCACHE_SERVER_PORT=14266`