### PR TITLE
make socks5 server optional in tuic-client, allow TCP/UDP forward only 

### DIFF
--- a/tuic-client/src/config.rs
+++ b/tuic-client/src/config.rs
@@ -231,8 +231,8 @@ pub struct ProxyConfig {
 #[educe(Default)]
 #[serde(deny_unknown_fields, default)]
 pub struct Local {
-	#[educe(Default(expression = "127.0.0.1:1080".parse().unwrap()))]
-	pub server: SocketAddr,
+	#[educe(Default = None)]
+	pub server: Option<SocketAddr>,
 
 	#[educe(Default = None)]
 	#[serde(deserialize_with = "deserialize_optional_bytes")]
@@ -631,6 +631,7 @@ mod tests {
 		assert_eq!(config.relay.gc_lifetime, Duration::from_secs(15));
 		assert!(!config.relay.skip_cert_verify);
 		assert_eq!(config.local.max_packet_size, 1500);
+		assert_eq!(config.local.server, Some("127.0.0.1:1080".parse().unwrap()));
 	}
 
 	#[test]
@@ -804,8 +805,8 @@ server = "127.0.0.1:1081"
 		let json5_config = include_str!("../tests/config/ipv6_server_address.json5");
 
 		let config = test_parse_config(json5_config, ".json5").unwrap();
-		assert!(config.local.server.is_ipv6());
-		assert_eq!(config.local.server.to_string(), "[::1]:1080");
+		assert!(config.local.server.as_ref().unwrap().is_ipv6());
+		assert_eq!(config.local.server.unwrap().to_string(), "[::1]:1080");
 	}
 
 	#[test]
@@ -828,7 +829,7 @@ server = "127.0.0.1:1081"
 		assert_eq!(config.log_level, "info");
 		assert_eq!(config.relay.server.0, "example.com");
 		assert_eq!(config.relay.server.1, 443);
-		assert_eq!(config.local.server.to_string(), "127.0.0.1:1080");
+		assert_eq!(config.local.server, Some("127.0.0.1:1080".parse().unwrap()));
 	}
 
 	#[test]
@@ -878,7 +879,7 @@ server = "127.0.0.1:1081"
 		assert!(!config.relay.pmtu);
 		assert_eq!(config.relay.gc_interval, Duration::from_secs(5));
 		assert_eq!(config.relay.gc_lifetime, Duration::from_secs(20));
-		assert_eq!(config.local.server.to_string(), "[::1]:1080");
+		assert_eq!(config.local.server, Some("[::1]:1080".parse().unwrap()));
 		assert_eq!(config.local.dual_stack, Some(false));
 		assert_eq!(config.local.max_packet_size, 2000);
 	}
@@ -1057,11 +1058,40 @@ server = "127.0.0.1:1081"
 		assert_eq!(config.relay.gc_lifetime, Duration::from_secs(60));
 		assert!(config.relay.skip_cert_verify);
 
-		assert_eq!(config.local.server.to_string(), "[::1]:9999");
+		assert_eq!(config.local.server.unwrap().to_string(), "[::1]:9999");
 		assert_eq!(config.local.username, Some(b"user123".to_vec()));
 		assert_eq!(config.local.password, Some(b"pass456".to_vec()));
 		assert_eq!(config.local.dual_stack, Some(true));
 		assert_eq!(config.local.max_packet_size, 2000);
+	}
+
+	#[test]
+	fn test_no_local_server() {
+		let toml_config = r#"
+		[relay]
+		server = "example.com:443"
+		uuid = "00000000-0000-0000-0000-000000000000"
+		password = "test"
+
+		[local]
+		tcp_forward = []
+		"#;
+
+		let config = test_parse_config(toml_config, ".toml").unwrap();
+		assert_eq!(config.local.server, None);
+	}
+
+	#[test]
+	fn test_no_local_section() {
+		let toml_config = r#"
+		[relay]
+		server = "example.com:443"
+		uuid = "00000000-0000-0000-0000-000000000000"
+		password = "test"
+		"#;
+
+		let config = test_parse_config(toml_config, ".toml").unwrap();
+		assert_eq!(config.local.server, None);
 	}
 
 	#[test]

--- a/tuic-client/src/config.rs
+++ b/tuic-client/src/config.rs
@@ -288,7 +288,7 @@ impl Config {
 
 		// Check if config file exists
 		if !path.exists() {
-			return Err(ConfigError::ConfigNotFound(path))?;
+			Err(ConfigError::ConfigNotFound(path.clone()))?;
 		}
 
 		let figmet = Figment::from(Serialized::defaults(Config::default()));

--- a/tuic-client/src/lib.rs
+++ b/tuic-client/src/lib.rs
@@ -28,7 +28,7 @@ pub use config::Config;
 pub struct AppContext {
 	pub conn_mgr: Arc<connection::ConnectionManager>,
 	/// SOCKS5 proxy server
-	pub socks5: Arc<socks5::Server>,
+	pub socks5: Option<Arc<socks5::Server>>,
 	/// UDP session registry for SOCKS5 UDP associate
 	pub socks5_udp_sessions: Cache<u16, socks5::UdpSession>,
 	/// UDP session registry for TCP/UDP port forwarding
@@ -101,13 +101,20 @@ impl AppContext {
 pub async fn run(cfg: Config) -> eyre::Result<()> {
 	let startup_mode = cfg.relay.startup_mode;
 	let conn_mgr = Arc::new(connection::ConnectionManager::build(cfg.relay).await?);
-	let socks5 = Arc::new(socks5::Server::new(
-		cfg.local.server,
-		cfg.local.dual_stack,
-		cfg.local.max_packet_size,
-		cfg.local.username,
-		cfg.local.password,
-	)?);
+	let socks5 = cfg
+		.local
+		.server
+		.map(|addr| {
+			socks5::Server::new(
+				addr,
+				cfg.local.dual_stack,
+				cfg.local.max_packet_size,
+				cfg.local.username,
+				cfg.local.password,
+			)
+			.map(Arc::new)
+		})
+		.transpose()?;
 
 	let socks5_idle = cfg.local.socks5_udp_idle_timeout;
 	// Cache acts as a safety-net evictor; the per-session idle watcher does the
@@ -142,7 +149,69 @@ pub async fn run(cfg: Config) -> eyre::Result<()> {
 		ctx.get_conn().await?;
 	}
 
+	let has_forwarding = !cfg.local.tcp_forward.is_empty() || !cfg.local.udp_forward.is_empty();
 	forward::start(ctx.clone(), cfg.local.tcp_forward, cfg.local.udp_forward).await;
-	socks5::Server::start(ctx.clone()).await;
+	if ctx.socks5.is_some() {
+		socks5::Server::start(ctx.clone()).await;
+	} else if has_forwarding {
+		// If SOCKS5 is disabled but forwarding is active, block forever to keep
+		// the background tasks alive.
+		std::future::pending::<()>().await;
+	}
 	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use tokio::time::{Duration, timeout};
+	use uuid::Uuid;
+
+	use super::*;
+	use crate::config::TcpForward;
+
+	fn install_crypto() {
+		#[cfg(feature = "aws-lc-rs")]
+		let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+		#[cfg(feature = "ring")]
+		let _ = rustls::crypto::ring::default_provider().install_default();
+	}
+
+	#[tokio::test]
+	async fn test_run_stays_alive_with_only_forwarding() {
+		install_crypto();
+		let mut cfg = Config::default();
+		cfg.relay.server = ("127.0.0.1".to_string(), 443);
+		cfg.relay.uuid = Uuid::new_v4();
+
+		cfg.local.server = None;
+		cfg.local.tcp_forward = vec![TcpForward {
+			listen: "127.0.0.1:0".parse().unwrap(),
+			remote: ("127.0.0.1".to_string(), 80),
+		}];
+
+		// run should block because has_forwarding is true and socks5 is None.
+		// We use timeout to verify it doesn't return immediately.
+		let result = timeout(Duration::from_millis(100), run(cfg)).await;
+
+		assert!(result.is_err(), "run() should have blocked and timed out");
+	}
+
+	#[tokio::test]
+	async fn test_run_exits_immediately_with_nothing() {
+		install_crypto();
+		let mut cfg = Config::default();
+		cfg.relay.server = ("127.0.0.1".to_string(), 443);
+		cfg.relay.uuid = Uuid::new_v4();
+
+		cfg.local.server = None;
+		cfg.local.tcp_forward = vec![];
+		cfg.local.udp_forward = vec![];
+
+		// run should return Ok(()) immediately.
+		let result = timeout(Duration::from_millis(100), run(cfg)).await;
+
+		assert!(result.is_ok(), "run() should have returned immediately");
+		assert!(result.unwrap().is_ok());
+	}
 }

--- a/tuic-client/src/socks5/mod.rs
+++ b/tuic-client/src/socks5/mod.rs
@@ -90,7 +90,10 @@ impl Server {
 	}
 
 	pub async fn start(ctx: Arc<crate::AppContext>) {
-		let server = ctx.socks5.clone();
+		let server = match ctx.socks5.as_ref() {
+			Some(s) => s.clone(),
+			None => return,
+		};
 
 		warn!("[socks5] server started, listening on {}", server.inner.local_addr().unwrap());
 

--- a/tuic-core/src/model/mod.rs
+++ b/tuic-core/src/model/mod.rs
@@ -267,7 +267,7 @@ where
 	}
 
 	fn collect_garbage(&mut self, timeout: Duration) {
-		for (_, session) in self.sessions.iter_mut() {
+		for session in self.sessions.values_mut() {
 			session.collect_garbage(timeout);
 		}
 		// Remove sessions that are empty and have been idle past the timeout.

--- a/tuic-server/src/lib.rs
+++ b/tuic-server/src/lib.rs
@@ -44,12 +44,12 @@ pub struct ServerGuard {
 /// a cancellation token for graceful shutdown.
 pub async fn run(cfg: Config) -> eyre::Result<ServerGuard> {
 	let mut online_counter = HashMap::new();
-	for (user, _) in cfg.users.iter() {
+	for user in cfg.users.keys() {
 		online_counter.insert(user.to_owned(), AtomicUsize::new(0));
 	}
 
 	let mut traffic_stats = HashMap::new();
-	for (user, _) in cfg.users.iter() {
+	for user in cfg.users.keys() {
 		traffic_stats.insert(user.to_owned(), (AtomicUsize::new(0), AtomicUsize::new(0)));
 	}
 

--- a/tuic-tests/tests/integration_tests.rs
+++ b/tuic-tests/tests/integration_tests.rs
@@ -303,7 +303,7 @@ async fn test_server_client_integration() -> eyre::Result<()> {
 			..Default::default()
 		},
 		local: tuic_client::config::Local {
-			server: "127.0.0.1:1080".parse()?,
+			server: "127.0.0.1:1080".parse().map(Some)?,
 			username: None,
 			password: None,
 			dual_stack: Some(false),
@@ -625,7 +625,7 @@ async fn test_tcp_udp_forward_integration() -> eyre::Result<()> {
 			// The SOCKS5 listener is required by the client runtime even though
 			// this test doesn't exercise it; pick a port distinct from the other
 			// integration tests.
-			server: "127.0.0.1:1083".parse()?,
+			server: "127.0.0.1:1083".parse().map(Some)?,
 			username: None,
 			password: None,
 			dual_stack: Some(false),
@@ -873,7 +873,7 @@ async fn test_ipv6_server_client_integration() -> eyre::Result<()> {
 			max_concurrent_streams: 1280,
 		},
 		local: tuic_client::config::Local {
-			server: "[::1]:1081".parse()?,
+			server: "[::1]:1081".parse().map(Some)?,
 			username: None,
 			password: None,
 			dual_stack: Some(false),
@@ -1076,7 +1076,7 @@ async fn test_client_proxy_configuration() -> eyre::Result<()> {
 			..Default::default()
 		},
 		local: tuic_client::config::Local {
-			server: "127.0.0.1:1082".parse()?,
+			server: "127.0.0.1:1082".parse().map(Some)?,
 			..Default::default()
 		},
 		log_level: "debug".to_string(),


### PR DESCRIPTION
feat(client): make SOCKS5 server optional
Assisted-by: Junie:gemini-3-flash

- Made the SOCKS5 server optional, allowing forwarding without starting a local proxy server.
- Introduced tests to ensure proper functionality when only TCP/UDP forwarding is enabled.

Also fix clippy errors:
- for_kv_map
- needless_return_with_question_mark