### PR TITLE
fix(server): close orphaned UDP sessions when parent QUIC connection drops

### DIFF
--- a/tuic-server/src/connection/udp_session.rs
+++ b/tuic-server/src/connection/udp_session.rs
@@ -11,7 +11,7 @@ use tokio::{
 	net::UdpSocket,
 	sync::{RwLock as AsyncRwLock, oneshot},
 };
-use tracing::{Instrument, Span, warn};
+use tracing::{Instrument, Span, debug, warn};
 use tuic_core::Address;
 
 use super::Connection;
@@ -94,39 +94,72 @@ impl UdpSession {
 			let mut rx = rx;
 			let mut timeout = tokio::time::interval(ctx_listening.cfg.stream_timeout);
 			timeout.reset();
+			let mut health_check = tokio::time::interval(ctx_listening.cfg.gc_interval);
+			health_check.reset();
+
+			enum Event {
+				Packet(Result<(Bytes, SocketAddr), IoError>),
+				Timeout,
+				CloseSignal,
+				HealthCheck,
+			}
 
 			loop {
-				let next;
-				tokio::select! {
-					recv = session_listening.recv() => next = recv,
-					// Avoid client didn't send `UDP-DROP` properly
-					_ = timeout.tick() => {
-						session_listening.close().await;
-						warn!("[packet] [{assoc_id:#06x}] UDP session timeout", assoc_id = session_listening.assoc_id);
-						continue;
-					},
-					// `UDP-DROP`
-					_ = &mut rx => break
-				}
-				timeout.reset();
-				let (pkt, addr) = match next {
-					Ok(v) => v,
-					Err(err) => {
-						warn!(
-							"[packet] [{assoc_id:#06x}] outbound listening error: {err}",
-							assoc_id = session_listening.assoc_id
-						);
-						continue;
-					}
+				let event = tokio::select! {
+					res = session_listening.recv()  => Event::Packet(res),
+					_  = timeout.tick()              => Event::Timeout,
+					_  = &mut rx                     => Event::CloseSignal,
+					_  = health_check.tick()          => Event::HealthCheck,
 				};
 
-				tokio::spawn(
-					conn_listening
-						.clone()
-						.relay_packet(pkt, Address::SocketAddress(addr), session_listening.assoc_id)
-						.log_err()
-						.instrument(span.clone()),
-				);
+				match event {
+					Event::Packet(res) => {
+						timeout.reset();
+
+						let (pkt, addr) = match res {
+							Ok(v) => v,
+							Err(err) => {
+								warn!(
+									"[packet] [{assoc_id:#06x}] outbound listening error: {err}",
+									assoc_id = session_listening.assoc_id
+								);
+								continue;
+							}
+						};
+
+						tokio::spawn(
+							conn_listening
+								.clone()
+								.relay_packet(pkt, Address::SocketAddress(addr), session_listening.assoc_id)
+								.log_err()
+								.instrument(span.clone()),
+						);
+					}
+					Event::Timeout => {
+						if conn_listening.is_closed() {
+							debug!(
+								"[packet] [{assoc_id:#06x}] parent connection closed, cleaning up",
+								assoc_id = session_listening.assoc_id
+							);
+							break;
+						}
+						session_listening.close().await;
+						warn!(
+							"[packet] [{assoc_id:#06x}] UDP session timeout",
+							assoc_id = session_listening.assoc_id
+						);
+					}
+					Event::CloseSignal => break,
+					Event::HealthCheck => {
+						if conn_listening.is_closed() {
+							debug!(
+								"[packet] [{assoc_id:#06x}] parent connection closed, cleaning up",
+								assoc_id = session_listening.assoc_id
+							);
+							break;
+						}
+					}
+				}
 			}
 			session_listening.udp_sessions.invalidate(&assoc_id).await;
 		};


### PR DESCRIPTION
## Problem

Issue #133 reports `No file descriptors available (os error 24)` on tuic-server after ~20 days of runtime, caused by file descriptor leak.

The UDP session listen task has no awareness of parent QUIC connection state. When a client disconnects without sending UDP-DROP:

1. The UDP session's sockets remain open
2. Cleanup relies solely on `stream_timeout` idle timeout (default 60s)
3. With frequent client reconnection, orphaned FDs accumulate over time

## Fix

Add two checks for `conn_listening.is_closed()` in the listen task:

1. **`timeout.tick()` branch** — before marking idle timeout, first check if the parent QUIC connection dropped
2. **New `health_check.tick()` branch** — periodic health check using `gc_interval` (default 10s) for prompt detection

This ensures orphaned UDP sessions are cleaned up within `gc_interval` (not `stream_timeout`) after the parent QUIC connection drops.

Closes #133
