### PR TITLE
revert(udp-session): restore lock-based UDP session maps (undo #114 moka)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3413,7 +3413,6 @@ dependencies = [
  "humantime",
  "humantime-serde",
  "json5 1.3.1",
- "moka",
  "num_cpus",
  "once_cell",
  "rustls",

--- a/tuic-client/Cargo.toml
+++ b/tuic-client/Cargo.toml
@@ -18,7 +18,6 @@ aws-lc-rs = ["tuic-core/aws-lc-rs", "dep:aws-lc-rs", "rustls/aws-lc-rs"]
 jemallocator = ["tikv-jemallocator"]
 
 [dependencies]
-moka = { version = "0.12", features = ["future"] }
 num_cpus = "1"
 bytes = { version = "1", default-features = false, features = ["std"] }
 

--- a/tuic-client/src/connection/handle_task.rs
+++ b/tuic-client/src/connection/handle_task.rs
@@ -125,7 +125,7 @@ impl Connection {
 					Address::SocketAddress(addr) => Socks5Address::SocketAddress(addr),
 				};
 
-				let session = self.socks5_udp_sessions.get(&assoc_id).await;
+				let session = self.socks5_udp_sessions.read().await.get(&assoc_id).cloned();
 
 				info!("[relay] [packet] [{assoc_id:#06x}] Checking session map.");
 
@@ -137,7 +137,7 @@ impl Connection {
 						);
 					}
 				} else {
-					let fwd_session = self.fwd_udp_sessions.get(&assoc_id).await;
+					let fwd_session = self.fwd_udp_sessions.read().await.get(&assoc_id).cloned();
 
 					if let Some(session) = fwd_session {
 						if let Err(err) = session.send(pkt).await {

--- a/tuic-client/src/connection/mod.rs
+++ b/tuic-client/src/connection/mod.rs
@@ -1,4 +1,5 @@
 use std::{
+	collections::HashMap,
 	net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket},
 	sync::{Arc, Mutex},
 	time::Duration,
@@ -6,7 +7,6 @@ use std::{
 
 use anyhow::Context;
 use crossbeam_utils::atomic::AtomicCell;
-use moka::future::Cache;
 use rustls::{
 	ClientConfig as RustlsClientConfig,
 	pki_types::{CertificateDer, ServerName, UnixTime},
@@ -36,8 +36,8 @@ mod socks5;
 use self::socks5::Socks5UdpSocket;
 
 /// Convenience type aliases for the two UDP session maps
-type Socks5Sessions = Cache<u16, crate::socks5::UdpSession>;
-type FwdSessions = Cache<u16, crate::forward::ForwardUdpSession>;
+type Socks5Sessions = Arc<AsyncRwLock<HashMap<u16, crate::socks5::UdpSession>>>;
+type FwdSessions = Arc<AsyncRwLock<HashMap<u16, crate::forward::ForwardUdpSession>>>;
 
 /// Default error code for QUIC connection
 pub const ERROR_CODE: VarInt = VarInt::from_u32(0);

--- a/tuic-client/src/forward.rs
+++ b/tuic-client/src/forward.rs
@@ -1,8 +1,8 @@
 use std::{
 	collections::HashMap,
 	net::{SocketAddr, TcpListener as StdTcpListener},
-	sync::{Arc, Mutex, atomic::Ordering},
-	time::{Duration, Instant},
+	sync::{Arc, atomic::Ordering},
+	time::Duration,
 };
 
 use bytes::Bytes;
@@ -12,7 +12,7 @@ use tokio::{
 	io::AsyncWriteExt,
 	net::{TcpListener, UdpSocket},
 };
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 use tuic_core::Address as TuicAddress;
 
 use crate::{
@@ -35,7 +35,6 @@ pub struct ForwardUdpSession {
 	socket: Arc<UdpSocket>,
 	src_addr: SocketAddr,
 	assoc_id: u16,
-	last_activity: Arc<Mutex<Instant>>,
 }
 
 impl ForwardUdpSession {
@@ -44,18 +43,7 @@ impl ForwardUdpSession {
 			socket,
 			src_addr,
 			assoc_id,
-			last_activity: Arc::new(Mutex::new(Instant::now())),
 		}
-	}
-
-	pub fn touch(&self) {
-		if let Ok(mut last) = self.last_activity.lock() {
-			*last = Instant::now();
-		}
-	}
-
-	pub fn idle_for(&self) -> Duration {
-		self.last_activity.lock().ok().map(|last| last.elapsed()).unwrap_or_default()
 	}
 
 	pub async fn send(&self, pkt: Bytes) -> Result<(), Error> {
@@ -67,7 +55,6 @@ impl ForwardUdpSession {
 			);
 			return Err(Error::Io(err));
 		}
-		self.touch();
 		Ok(())
 	}
 }
@@ -141,10 +128,7 @@ async fn run_udp_forwarder(entry: UdpForward, ctx: Arc<crate::AppContext>) {
 	let socket = match UdpSocket::bind(entry.listen).await {
 		Ok(s) => s,
 		Err(err) => {
-			error!(
-				"[forward-udp] failed to bind {addr}: {err}; forwarder will not start",
-				addr = entry.listen
-			);
+			warn!("[forward-udp] failed to bind {addr}: {err}", addr = entry.listen);
 			return;
 		}
 	};
@@ -157,38 +141,24 @@ async fn run_udp_forwarder(entry: UdpForward, ctx: Arc<crate::AppContext>) {
 	);
 
 	let mut buf = vec![0u8; 65535];
-	// Per-forwarder reverse map from client src addr to assoc_id.
-	// Shared with idle_watcher tasks so expiry can clean both sides atomically
-	// (cache slot + reverse map entry), preventing stale entries from routing
-	// future packets onto a dissociated relay session.
-	let src_map: Arc<Mutex<HashMap<SocketAddr, u16>>> = Arc::new(Mutex::new(HashMap::new()));
-
-	let mut consecutive_recv_errors: u32 = 0;
-	const MAX_CONSECUTIVE_RECV_ERRORS: u32 = 64;
+	// Map from client src addr to assoc_id for this forwarder instance
+	let mut src_map: HashMap<SocketAddr, u16> = HashMap::new();
 
 	loop {
 		match socket.recv_from(&mut buf).await {
 			Ok((n, src_addr)) => {
-				consecutive_recv_errors = 0;
 				let pkt = Bytes::copy_from_slice(&buf[..n]);
-
-				let assoc_id = {
-					let existing = src_map.lock().unwrap().get(&src_addr).copied();
-					match existing {
-						// Reuse path: refresh activity if the session is still live; if it was
-						// already evicted, drop the stale reverse-map entry and fall through to
-						// allocating a fresh assoc_id.
-						Some(id) => match ctx.fwd_udp_sessions.get(&id).await {
-							Some(session) => {
-								session.touch();
-								id
-							}
-							None => {
-								src_map.lock().unwrap().remove(&src_addr);
-								allocate_fwd_session(&ctx, &socket, &src_map, src_addr, entry.timeout).await
-							}
-						},
-						None => allocate_fwd_session(&ctx, &socket, &src_map, src_addr, entry.timeout).await,
+				let assoc_id = match src_map.get(&src_addr).cloned() {
+					Some(id) => id,
+					None => {
+						let id = 0x8000 | (ctx.next_fwd_assoc_id.fetch_add(1, Ordering::Relaxed) & 0x7fff);
+						// register session
+						let session = ForwardUdpSession::new(socket.clone(), src_addr, id);
+						ctx.fwd_udp_sessions.write().await.insert(id, session);
+						src_map.insert(src_addr, id);
+						// Spawn timeout watcher
+						tokio::spawn(expire_after(id, entry.timeout, ctx.clone()));
+						id
 					}
 				};
 
@@ -206,190 +176,21 @@ async fn run_udp_forwarder(entry: UdpForward, ctx: Arc<crate::AppContext>) {
 					}
 				});
 			}
-			Err(err) => {
-				// recv_from on a bound UDP socket should normally not error per-packet;
-				// when it does (resource exhaustion, ICMP unreachable on Windows, etc.)
-				// log it, but also count to avoid a hot-spinning loop on a permanently
-				// broken socket (e.g. EBADF after the socket is somehow closed).
-				consecutive_recv_errors += 1;
-				warn!(
-					"[forward-udp] recv_from error ({consecutive_recv_errors}/{MAX_CONSECUTIVE_RECV_ERRORS}) on {listen}: \
-					 {err}",
-					listen = entry.listen
-				);
-				if consecutive_recv_errors >= MAX_CONSECUTIVE_RECV_ERRORS {
-					error!(
-						"[forward-udp] socket on {listen} appears unrecoverable after {consecutive_recv_errors} consecutive \
-						 errors; shutting down this forwarder",
-						listen = entry.listen
-					);
-					return;
-				}
-				// Brief backoff so a transient error storm doesn't pin a CPU core.
-				tokio::time::sleep(Duration::from_millis(50)).await;
-			}
+			Err(err) => warn!("[forward-udp] recv_from error: {err}"),
 		}
 	}
 }
 
-/// Allocate a fresh assoc_id in the forwarder half of the 16-bit space
-/// (`0x8000..=0xFFFF`), register the session, and arm an idle watcher.
-async fn allocate_fwd_session(
-	ctx: &Arc<crate::AppContext>,
-	socket: &Arc<UdpSocket>,
-	src_map: &Arc<Mutex<HashMap<SocketAddr, u16>>>,
-	src_addr: SocketAddr,
-	timeout: Duration,
-) -> u16 {
-	let id = 0x8000 | (ctx.next_fwd_assoc_id.fetch_add(1, Ordering::Relaxed) & 0x7fff);
-	let session = ForwardUdpSession::new(socket.clone(), src_addr, id);
-	ctx.fwd_udp_sessions.insert(id, session).await;
-	src_map.lock().unwrap().insert(src_addr, id);
-	tokio::spawn(idle_watcher(id, src_addr, timeout, ctx.clone(), src_map.clone()));
-	id
-}
-
-/// Remove `src_addr` from `src_map` **only** if it still points at `assoc_id`.
-///
-/// This is the successor-safety guard the idle watcher needs: between the
-/// watcher waking up and acquiring the lock, the same `src_addr` may have been
-/// reassigned to a brand-new session (typical when the client falls silent,
-/// the watcher expires it, and the next packet arrives before the watcher
-/// returns). We must not clobber that successor's entry. Returns true if the
-/// entry was removed.
-fn drop_src_map_if_matches(src_map: &Mutex<HashMap<SocketAddr, u16>>, src_addr: SocketAddr, assoc_id: u16) -> bool {
-	let mut map = src_map.lock().unwrap();
-	match map.get(&src_addr).copied() {
-		Some(existing) if existing == assoc_id => {
-			map.remove(&src_addr);
-			true
-		}
-		_ => false,
-	}
-}
-
-/// Idle-based session reaper. Sleeps until the session's `last_activity`
-/// indicates it has been quiet for `timeout`, then removes the session from
-/// both the cache and the per-forwarder reverse map and dissociates from the
-/// relay. Either map being mutated under us is fine — we re-check on each
-/// wake-up rather than assuming the deadline is fixed at spawn time.
-async fn idle_watcher(
-	assoc_id: u16,
-	src_addr: SocketAddr,
-	timeout: Duration,
-	ctx: Arc<crate::AppContext>,
-	src_map: Arc<Mutex<HashMap<SocketAddr, u16>>>,
-) {
-	if timeout.is_zero() {
-		return;
-	}
-	loop {
-		let session = match ctx.fwd_udp_sessions.get(&assoc_id).await {
-			Some(s) => s,
-			None => {
-				// Already evicted (cache TTI or other path); also drop reverse-map entry
-				// only if it still points at *this* id to avoid clobbering a successor.
-				drop_src_map_if_matches(&src_map, src_addr, assoc_id);
-				return;
+async fn expire_after(assoc_id: u16, timeout: Duration, ctx: Arc<crate::AppContext>) {
+	tokio::time::sleep(timeout).await;
+	let mut w = ctx.fwd_udp_sessions.write().await;
+	if let Some(_s) = w.remove(&assoc_id) {
+		debug!("[forward-udp] [{assoc:#06x}] timeout; dissociate", assoc = assoc_id);
+		drop(w);
+		if let Ok(conn) = ctx.get_conn().await {
+			if let Err(err) = conn.dissociate(assoc_id).await {
+				warn!("[forward-udp] [{assoc:#06x}] dissociate error: {err}", assoc = assoc_id);
 			}
-		};
-		let idle = session.idle_for();
-		drop(session);
-
-		if idle >= timeout {
-			if ctx.fwd_udp_sessions.remove(&assoc_id).await.is_some() {
-				debug!(
-					"[forward-udp] [{assoc:#06x}] idle for {idle:?} (>= {timeout:?}); dissociate",
-					assoc = assoc_id
-				);
-				if let Ok(conn) = ctx.get_conn().await
-					&& let Err(err) = conn.dissociate(assoc_id).await
-				{
-					warn!("[forward-udp] [{assoc:#06x}] dissociate error: {err}", assoc = assoc_id);
-				}
-			}
-			drop_src_map_if_matches(&src_map, src_addr, assoc_id);
-			return;
 		}
-
-		let remaining = timeout - idle;
-		tokio::time::sleep(remaining.max(Duration::from_millis(100))).await;
-	}
-}
-
-#[cfg(test)]
-mod tests {
-	use std::time::Duration;
-
-	use super::*;
-
-	async fn bound_socket() -> Arc<UdpSocket> {
-		Arc::new(UdpSocket::bind("127.0.0.1:0").await.expect("bind 127.0.0.1:0"))
-	}
-
-	#[tokio::test]
-	async fn forward_session_idle_grows_and_touch_resets() {
-		let socket = bound_socket().await;
-		let session = ForwardUdpSession::new(socket, "127.0.0.1:1".parse().unwrap(), 0x8000);
-
-		assert!(session.idle_for() < Duration::from_millis(50));
-		tokio::time::sleep(Duration::from_millis(80)).await;
-		assert!(session.idle_for() >= Duration::from_millis(60));
-
-		session.touch();
-		assert!(session.idle_for() < Duration::from_millis(30));
-	}
-
-	#[tokio::test]
-	async fn forward_session_send_delivers_and_touches() {
-		// Send-side socket bound to ephemeral; the session's "src_addr" is the
-		// receive-side socket where the packet will land. We then read it back to
-		// confirm delivery, and verify last_activity was bumped by the send.
-		let send_socket = bound_socket().await;
-		let recv_socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
-		let recv_addr = recv_socket.local_addr().unwrap();
-
-		let session = ForwardUdpSession::new(send_socket, recv_addr, 0x8001);
-		tokio::time::sleep(Duration::from_millis(80)).await;
-		assert!(session.idle_for() >= Duration::from_millis(60));
-
-		session
-			.send(Bytes::from_static(b"hello"))
-			.await
-			.expect("send should succeed on localhost");
-
-		let mut buf = [0u8; 16];
-		let (n, _) = tokio::time::timeout(Duration::from_secs(1), recv_socket.recv_from(&mut buf))
-			.await
-			.expect("packet should arrive within 1s")
-			.expect("recv ok");
-		assert_eq!(&buf[..n], b"hello");
-
-		// send() must have touched last_activity.
-		assert!(
-			session.idle_for() < Duration::from_millis(30),
-			"send must reset idle, got {:?}",
-			session.idle_for()
-		);
-	}
-
-	#[test]
-	fn src_map_cleanup_removes_only_matching_id() {
-		let map: Mutex<HashMap<SocketAddr, u16>> = Mutex::new(HashMap::new());
-		let addr: SocketAddr = "127.0.0.1:1234".parse().unwrap();
-
-		map.lock().unwrap().insert(addr, 0x8001);
-
-		// Stale watcher (id 0x8000) attempts cleanup — must NOT touch the entry
-		// belonging to the live successor (id 0x8001).
-		assert!(!drop_src_map_if_matches(&map, addr, 0x8000));
-		assert_eq!(map.lock().unwrap().get(&addr).copied(), Some(0x8001));
-
-		// Live watcher (id 0x8001) cleans up its own entry.
-		assert!(drop_src_map_if_matches(&map, addr, 0x8001));
-		assert!(map.lock().unwrap().get(&addr).is_none());
-
-		// Cleanup against an empty slot is a no-op.
-		assert!(!drop_src_map_if_matches(&map, addr, 0x8001));
 	}
 }

--- a/tuic-client/src/lib.rs
+++ b/tuic-client/src/lib.rs
@@ -1,14 +1,16 @@
 // Library interface for tuic-client
 // This allows the client to be used as a library in integration tests
 
-use std::sync::{
-	Arc,
-	atomic::{AtomicBool, AtomicU16, Ordering},
+use std::{
+	collections::HashMap,
+	sync::{
+		Arc,
+		atomic::{AtomicBool, AtomicU16, Ordering},
+	},
 };
 
-use moka::future::Cache;
 use tokio::{
-	sync::Mutex as AsyncMutex,
+	sync::{Mutex as AsyncMutex, RwLock as AsyncRwLock},
 	time::{Duration, sleep},
 };
 use tracing::{error, warn};
@@ -26,13 +28,14 @@ pub use config::Config;
 /// Passed as `Arc<AppContext>` throughout the client; eliminates global
 /// statics.
 pub struct AppContext {
+	/// Manages the QUIC endpoint and current connection
 	pub conn_mgr: Arc<connection::ConnectionManager>,
 	/// SOCKS5 proxy server
-	pub socks5: Option<Arc<socks5::Server>>,
+	pub socks5: Arc<socks5::Server>,
 	/// UDP session registry for SOCKS5 UDP associate
-	pub socks5_udp_sessions: Cache<u16, socks5::UdpSession>,
+	pub socks5_udp_sessions: Arc<AsyncRwLock<HashMap<u16, socks5::UdpSession>>>,
 	/// UDP session registry for TCP/UDP port forwarding
-	pub fwd_udp_sessions: Cache<u16, forward::ForwardUdpSession>,
+	pub fwd_udp_sessions: Arc<AsyncRwLock<HashMap<u16, forward::ForwardUdpSession>>>,
 	/// Next association ID counter for UDP forwarding (high bit set to avoid
 	/// collisions with SOCKS5 IDs)
 	pub next_fwd_assoc_id: AtomicU16,
@@ -42,8 +45,6 @@ pub struct AppContext {
 	pub first_connected: AtomicBool,
 	/// Serializes first-connection logic under non-eager modes.
 	pub first_connect_lock: AsyncMutex<()>,
-	/// Idle timeout applied to each SOCKS5 UDP ASSOCIATE session.
-	pub socks5_udp_idle_timeout: Duration,
 }
 
 impl AppContext {
@@ -101,46 +102,24 @@ impl AppContext {
 pub async fn run(cfg: Config) -> eyre::Result<()> {
 	let startup_mode = cfg.relay.startup_mode;
 	let conn_mgr = Arc::new(connection::ConnectionManager::build(cfg.relay).await?);
-	let socks5 = cfg
-		.local
-		.server
-		.map(|addr| {
-			socks5::Server::new(
-				addr,
-				cfg.local.dual_stack,
-				cfg.local.max_packet_size,
-				cfg.local.username,
-				cfg.local.password,
-			)
-			.map(Arc::new)
-		})
-		.transpose()?;
-
-	let socks5_idle = cfg.local.socks5_udp_idle_timeout;
-	// Cache acts as a safety-net evictor; the per-session idle watcher does the
-	// authoritative cleanup (with proper `dissociate` to the relay). The cache TTI
-	// is sized larger than the watcher's interval so the watcher wins under normal
-	// conditions and the cache only fires if the watcher is stuck or missing.
-	let socks5_cache_tti = socks5_idle.saturating_mul(2).max(Duration::from_secs(60));
-	let fwd_cache_tti = cfg
-		.local
-		.udp_forward
-		.iter()
-		.map(|f| f.timeout)
-		.max()
-		.unwrap_or(Duration::from_secs(60))
-		.saturating_mul(2);
-
+	let socks5 = Arc::new(socks5::Server::new(
+		cfg.local
+			.server
+			.ok_or_else(|| eyre::eyre!("`local.server` (SOCKS5 listen address) is required"))?,
+		cfg.local.dual_stack,
+		cfg.local.max_packet_size,
+		cfg.local.username,
+		cfg.local.password,
+	)?);
 	let ctx = Arc::new(AppContext {
 		conn_mgr,
 		socks5,
-		socks5_udp_sessions: Cache::builder().max_capacity(1024).time_to_idle(socks5_cache_tti).build(),
-		fwd_udp_sessions: Cache::builder().max_capacity(1024).time_to_idle(fwd_cache_tti).build(),
+		socks5_udp_sessions: Arc::new(AsyncRwLock::new(HashMap::new())),
+		fwd_udp_sessions: Arc::new(AsyncRwLock::new(HashMap::new())),
 		next_fwd_assoc_id: AtomicU16::new(0),
 		startup_mode,
 		first_connected: AtomicBool::new(false),
 		first_connect_lock: AsyncMutex::new(()),
-		socks5_udp_idle_timeout: socks5_idle,
 	});
 
 	// Eager mode keeps the original behavior: connect at startup and exit on
@@ -149,69 +128,7 @@ pub async fn run(cfg: Config) -> eyre::Result<()> {
 		ctx.get_conn().await?;
 	}
 
-	let has_forwarding = !cfg.local.tcp_forward.is_empty() || !cfg.local.udp_forward.is_empty();
 	forward::start(ctx.clone(), cfg.local.tcp_forward, cfg.local.udp_forward).await;
-	if ctx.socks5.is_some() {
-		socks5::Server::start(ctx.clone()).await;
-	} else if has_forwarding {
-		// If SOCKS5 is disabled but forwarding is active, block forever to keep
-		// the background tasks alive.
-		std::future::pending::<()>().await;
-	}
+	socks5::Server::start(ctx.clone()).await;
 	Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-	use tokio::time::{Duration, timeout};
-	use uuid::Uuid;
-
-	use super::*;
-	use crate::config::TcpForward;
-
-	fn install_crypto() {
-		#[cfg(feature = "aws-lc-rs")]
-		let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-
-		#[cfg(feature = "ring")]
-		let _ = rustls::crypto::ring::default_provider().install_default();
-	}
-
-	#[tokio::test]
-	async fn test_run_stays_alive_with_only_forwarding() {
-		install_crypto();
-		let mut cfg = Config::default();
-		cfg.relay.server = ("127.0.0.1".to_string(), 443);
-		cfg.relay.uuid = Uuid::new_v4();
-
-		cfg.local.server = None;
-		cfg.local.tcp_forward = vec![TcpForward {
-			listen: "127.0.0.1:0".parse().unwrap(),
-			remote: ("127.0.0.1".to_string(), 80),
-		}];
-
-		// run should block because has_forwarding is true and socks5 is None.
-		// We use timeout to verify it doesn't return immediately.
-		let result = timeout(Duration::from_millis(100), run(cfg)).await;
-
-		assert!(result.is_err(), "run() should have blocked and timed out");
-	}
-
-	#[tokio::test]
-	async fn test_run_exits_immediately_with_nothing() {
-		install_crypto();
-		let mut cfg = Config::default();
-		cfg.relay.server = ("127.0.0.1".to_string(), 443);
-		cfg.relay.uuid = Uuid::new_v4();
-
-		cfg.local.server = None;
-		cfg.local.tcp_forward = vec![];
-		cfg.local.udp_forward = vec![];
-
-		// run should return Ok(()) immediately.
-		let result = timeout(Duration::from_millis(100), run(cfg)).await;
-
-		assert!(result.is_ok(), "run() should have returned immediately");
-		assert!(result.unwrap().is_ok());
-	}
 }

--- a/tuic-client/src/socks5/handle_task.rs
+++ b/tuic-client/src/socks5/handle_task.rs
@@ -1,19 +1,16 @@
-use std::{io::ErrorKind, sync::Arc, time::Duration};
+use std::sync::Arc;
 
 use socks5_proto::{Address, Reply};
 use socks5_server::{
 	Associate, Bind, Connect,
 	connection::{associate, bind, connect},
 };
-use tokio::{
-	io::{self, AsyncWriteExt},
-	time,
-};
-use tracing::{debug, error, info, warn};
+use tokio::io::{self, AsyncWriteExt};
+use tracing::{debug, info, warn};
 use tuic_core::Address as TuicAddress;
 
 use super::{Server, udp_session::UdpSession};
-use crate::{connection::ERROR_CODE, error::Error};
+use crate::connection::ERROR_CODE;
 
 impl Server {
 	pub async fn handle_associate(
@@ -32,6 +29,16 @@ impl Server {
 			dual_stack
 		);
 
+		// Check for existing session with same ID
+		{
+			let sessions = ctx.socks5_udp_sessions.read().await;
+			if sessions.contains_key(&assoc_id) {
+				warn!(
+					"[socks5] [{peer_addr}] [associate] [{assoc_id:#06x}] session ID already exists! This may cause conflicts"
+				);
+			}
+		}
+
 		match UdpSession::new(assoc_id, peer_addr, local_ip, dual_stack, max_pkt_size) {
 			Ok(session) => {
 				let local_addr = session.local_addr().unwrap();
@@ -45,31 +52,20 @@ impl Server {
 					}
 				};
 
-				ctx.socks5_udp_sessions.insert(assoc_id, session.clone()).await;
+				{
+					ctx.socks5_udp_sessions.write().await.insert(assoc_id, session.clone());
+				}
 
-				let idle_timeout = ctx.socks5_udp_idle_timeout;
 				let ctx_loop = ctx.clone();
-				let session_for_recv = session.clone();
 				let handle_local_incoming_pkt = async move {
 					loop {
-						let (pkt, target_addr) = match session_for_recv.recv().await {
+						let (pkt, target_addr) = match session.recv().await {
 							Ok(res) => res,
-							Err(Error::Io(err)) if err.kind() == ErrorKind::Other => {
-								// Protocol-level rejects (wrong source addr, fragmented packet, etc.)
-								// — drop this packet and keep serving the session.
+							Err(err) => {
 								warn!(
-									"[socks5] [{peer_addr}] [associate] [{assoc_id:#06x}] dropping malformed UDP packet: {err}"
+									"[socks5] [{peer_addr}] [associate] [{assoc_id:#06x}] failed to receive UDP packet: {err}"
 								);
 								continue;
-							}
-							Err(err) => {
-								// Underlying socket failure — the session is no longer functional,
-								// stop the recv loop so the cleanup path runs.
-								error!(
-									"[socks5] [{peer_addr}] [associate] [{assoc_id:#06x}] unrecoverable UDP recv error, \
-									 ending session: {err}"
-								);
-								break;
 							}
 						};
 
@@ -100,50 +96,20 @@ impl Server {
 					}
 				};
 
-				// Defensive idle watcher: walks up against the session's `last_activity`
-				// (touched on every send/recv) and tears the session down when no traffic
-				// has flowed for the configured timeout. Protects the relay from sessions
-				// stranded by clients that hold the control TCP open without ever sending
-				// UDP, and reclaims the cache slot for new associations.
-				let session_for_idle = session.clone();
-				let idle_watcher = async move {
-					if idle_timeout.is_zero() {
-						std::future::pending::<()>().await;
-						return;
+				match tokio::select! {
+					res = assoc.wait_until_closed() => res,
+					_ = handle_local_incoming_pkt => unreachable!(),
+				} {
+					Ok(()) => {}
+					Err(err) => {
+						warn!("[socks5] [{peer_addr}] [associate] [{assoc_id:#06x}] associate connection error: {err}")
 					}
-					loop {
-						let idle = session_for_idle.idle_for();
-						if idle >= idle_timeout {
-							warn!(
-								"[socks5] [{peer_addr}] [associate] [{assoc_id:#06x}] idle for {idle:?} (>= \
-								 {idle_timeout:?}); closing session"
-							);
-							return;
-						}
-						let remaining = idle_timeout - idle;
-						time::sleep(remaining.max(Duration::from_millis(100))).await;
-					}
-				};
-
-				tokio::select! {
-					res = assoc.wait_until_closed() => {
-						if let Err(err) = res {
-							warn!("[socks5] [{peer_addr}] [associate] [{assoc_id:#06x}] associate connection error: {err}");
-						}
-					}
-					_ = handle_local_incoming_pkt => {}
-					_ = idle_watcher => {}
 				}
 
 				debug!("[socks5] [{peer_addr}] [associate] [{assoc_id:#06x}] stopped associating");
 
-				// Remove may legitimately return None: the cache TTI or a parallel cleanup
-				// path may have evicted the entry first. Either way the session is dead;
-				// just continue to the dissociate handshake with the relay.
-				if ctx.socks5_udp_sessions.remove(&assoc_id).await.is_none() {
-					debug!(
-						"[socks5] [{peer_addr}] [associate] [{assoc_id:#06x}] session already absent from registry on cleanup"
-					);
+				{
+					ctx.socks5_udp_sessions.write().await.remove(&assoc_id).unwrap();
 				}
 
 				if let Ok(conn) = ctx.get_conn().await

--- a/tuic-client/src/socks5/mod.rs
+++ b/tuic-client/src/socks5/mod.rs
@@ -6,15 +6,13 @@ use std::{
 	},
 };
 
-use moka::future::Cache;
 use socket2::{Domain, Protocol, SockAddr, Socket, Type};
-use socks5_proto::{Address, Reply};
 use socks5_server::{
 	Auth, Connection, Server as Socks5Server,
 	auth::{NoAuth, Password},
 };
 use tokio::net::TcpListener;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 use crate::error::Error;
 
@@ -90,10 +88,7 @@ impl Server {
 	}
 
 	pub async fn start(ctx: Arc<crate::AppContext>) {
-		let server = match ctx.socks5.as_ref() {
-			Some(s) => s.clone(),
-			None => return,
-		};
+		let server = ctx.socks5.clone();
 
 		warn!("[socks5] server started, listening on {}", server.inner.local_addr().unwrap());
 
@@ -106,23 +101,11 @@ impl Server {
 					let ctx = ctx.clone();
 					tokio::spawn(async move {
 						match conn.handshake().await {
-							Ok(Connection::Associate(associate, _)) => match Self::allocate_assoc_id(&server, &ctx).await {
-								Some(assoc_id) => {
-									info!("[socks5] [{addr}] [associate] [{assoc_id:#06x}]");
-									Self::handle_associate(associate, assoc_id, server.dual_stack, server.max_pkt_size, ctx)
-										.await;
-								}
-								None => {
-									error!(
-										"[socks5] [{addr}] [associate] no available assoc_id (SOCKS5 ID space [0x0000,0x7FFF] \
-										 exhausted); rejecting"
-									);
-									if let Ok(mut assoc) = associate.reply(Reply::GeneralFailure, Address::unspecified()).await
-									{
-										let _ = assoc.shutdown().await;
-									}
-								}
-							},
+							Ok(Connection::Associate(associate, _)) => {
+								let assoc_id = server.next_assoc_id.fetch_add(1, Ordering::Relaxed);
+								info!("[socks5] [{addr}] [associate] [{assoc_id:#06x}]");
+								Self::handle_associate(associate, assoc_id, server.dual_stack, server.max_pkt_size, ctx).await;
+							}
 							Ok(Connection::Bind(bind, _)) => {
 								info!("[socks5] [{addr}] [bind]");
 								Self::handle_bind(bind).await;
@@ -140,131 +123,5 @@ impl Server {
 				Err(err) => warn!("[socks5] failed to establish connection: {err}"),
 			}
 		}
-	}
-
-	/// Allocate a fresh assoc_id in the SOCKS5 half of the 16-bit space
-	/// (`0x0000..=0x7FFF`). The high half (`0x8000..=0xFFFF`) is reserved for
-	/// the UDP forwarder, so the two never collide.
-	///
-	/// Skips IDs currently in use by the session cache. Returns `None` only
-	/// when every slot in the 32K-entry space is taken (i.e. the cache is
-	/// saturated by live SOCKS5 sessions), which would also be blocked by the
-	/// 1024 cache cap in practice.
-	async fn allocate_assoc_id(server: &Arc<Self>, ctx: &Arc<crate::AppContext>) -> Option<u16> {
-		allocate_socks5_assoc_id(&server.next_assoc_id, &ctx.socks5_udp_sessions).await
-	}
-}
-
-/// SOCKS5 half of the 16-bit assoc_id space.
-pub(crate) const SOCKS5_ID_MASK: u16 = 0x7FFF;
-
-/// Allocate a fresh SOCKS5 assoc_id from `counter`, skipping any ID currently
-/// present in `cache`. Returns `None` after scanning all 32K slots without
-/// finding a free one. Extracted so the lookup-skip + wraparound behaviour can
-/// be unit-tested without standing up a full `AppContext`.
-pub(crate) async fn allocate_socks5_assoc_id<V>(counter: &AtomicU16, cache: &Cache<u16, V>) -> Option<u16>
-where
-	V: Clone + Send + Sync + 'static,
-{
-	const MAX_TRIES: u32 = (SOCKS5_ID_MASK as u32) + 1;
-
-	for _ in 0..MAX_TRIES {
-		let id = counter.fetch_add(1, Ordering::Relaxed) & SOCKS5_ID_MASK;
-		if !cache.contains_key(&id) {
-			return Some(id);
-		}
-	}
-	None
-}
-
-#[cfg(test)]
-mod tests {
-	use moka::future::Cache;
-
-	use super::*;
-
-	fn build_cache(capacity: u64) -> Cache<u16, ()> {
-		Cache::builder().max_capacity(capacity).build()
-	}
-
-	#[tokio::test]
-	async fn assoc_id_stays_in_socks5_half() {
-		let counter = AtomicU16::new(0);
-		let cache: Cache<u16, ()> = build_cache(1024);
-
-		for _ in 0..10_000 {
-			let id = allocate_socks5_assoc_id(&counter, &cache).await.unwrap();
-			assert!(id <= SOCKS5_ID_MASK, "id {id:#06x} outside SOCKS5 half");
-		}
-	}
-
-	#[tokio::test]
-	async fn assoc_id_wraps_through_high_half_back_to_low() {
-		// Start the counter near a wrap so a single allocation crosses 0xFFFF -> 0x0000
-		// at the raw-counter level. The mask should keep the visible id below 0x8000.
-		let counter = AtomicU16::new(0xFFFE);
-		let cache: Cache<u16, ()> = build_cache(8);
-
-		let a = allocate_socks5_assoc_id(&counter, &cache).await.unwrap();
-		let b = allocate_socks5_assoc_id(&counter, &cache).await.unwrap();
-		let c = allocate_socks5_assoc_id(&counter, &cache).await.unwrap();
-		let d = allocate_socks5_assoc_id(&counter, &cache).await.unwrap();
-
-		for id in [a, b, c, d] {
-			assert!(id <= SOCKS5_ID_MASK, "id {id:#06x} leaked into forwarder half");
-		}
-		// 0xFFFE & 0x7FFF = 0x7FFE, 0xFFFF & 0x7FFF = 0x7FFF,
-		// 0x0000 & 0x7FFF = 0x0000, 0x0001 & 0x7FFF = 0x0001.
-		assert_eq!([a, b, c, d], [0x7FFE, 0x7FFF, 0x0000, 0x0001]);
-	}
-
-	#[tokio::test]
-	async fn assoc_id_skips_occupied() {
-		let counter = AtomicU16::new(0);
-		let cache: Cache<u16, ()> = build_cache(1024);
-		cache.insert(0, ()).await;
-		cache.insert(1, ()).await;
-		cache.insert(2, ()).await;
-
-		let id = allocate_socks5_assoc_id(&counter, &cache).await.unwrap();
-		assert_eq!(id, 3, "should skip the three pre-inserted ids");
-	}
-
-	#[tokio::test]
-	async fn assoc_id_saturated_returns_none() {
-		// Cap large enough to hold the whole SOCKS5 half so no entries are evicted
-		// while we fill it.
-		let cap = (SOCKS5_ID_MASK as u64) + 1;
-		let counter = AtomicU16::new(0);
-		let cache: Cache<u16, ()> = build_cache(cap);
-		for id in 0..=SOCKS5_ID_MASK {
-			cache.insert(id, ()).await;
-		}
-		cache.run_pending_tasks().await;
-
-		assert!(
-			allocate_socks5_assoc_id(&counter, &cache).await.is_none(),
-			"allocator must surrender when every SOCKS5 slot is taken"
-		);
-	}
-
-	#[tokio::test]
-	async fn assoc_id_freed_slot_is_reused() {
-		let cap = (SOCKS5_ID_MASK as u64) + 1;
-		let counter = AtomicU16::new(0);
-		let cache: Cache<u16, ()> = build_cache(cap);
-		for id in 0..=SOCKS5_ID_MASK {
-			cache.insert(id, ()).await;
-		}
-		cache.run_pending_tasks().await;
-		assert!(allocate_socks5_assoc_id(&counter, &cache).await.is_none());
-
-		// Free one specific slot; the next allocation should land on it after the
-		// counter sweeps back around.
-		cache.invalidate(&0x0123).await;
-		cache.run_pending_tasks().await;
-
-		let id = allocate_socks5_assoc_id(&counter, &cache).await.unwrap();
-		assert_eq!(id, 0x0123);
 	}
 }

--- a/tuic-client/src/socks5/udp_session.rs
+++ b/tuic-client/src/socks5/udp_session.rs
@@ -1,8 +1,7 @@
 use std::{
 	io::Error as IoError,
 	net::{IpAddr, SocketAddr, UdpSocket as StdUdpSocket},
-	sync::{Arc, Mutex},
-	time::Instant,
+	sync::Arc,
 };
 
 use bytes::Bytes;
@@ -19,7 +18,6 @@ pub struct UdpSession {
 	socket: Arc<AssociatedUdpSocket>,
 	assoc_id: u16,
 	ctrl_addr: SocketAddr,
-	last_activity: Arc<Mutex<Instant>>,
 }
 
 impl UdpSession {
@@ -92,18 +90,7 @@ impl UdpSession {
 			socket: Arc::new(AssociatedUdpSocket::from((socket, max_pkt_size))),
 			assoc_id,
 			ctrl_addr,
-			last_activity: Arc::new(Mutex::new(Instant::now())),
 		})
-	}
-
-	pub fn touch(&self) {
-		if let Ok(mut last) = self.last_activity.lock() {
-			*last = Instant::now();
-		}
-	}
-
-	pub fn idle_for(&self) -> std::time::Duration {
-		self.last_activity.lock().ok().map(|last| last.elapsed()).unwrap_or_default()
 	}
 
 	pub async fn send(&self, pkt: Bytes, mut src_addr: Address) -> Result<(), Error> {
@@ -134,7 +121,6 @@ impl UdpSession {
 			return Err(Error::Io(err));
 		}
 
-		self.touch();
 		Ok(())
 	}
 
@@ -185,71 +171,10 @@ impl UdpSession {
 			assoc_id = self.assoc_id
 		);
 
-		self.touch();
 		Ok((pkt, dst_addr))
 	}
 
 	pub fn local_addr(&self) -> Result<SocketAddr, IoError> {
 		self.socket.local_addr()
-	}
-}
-
-#[cfg(test)]
-mod tests {
-	use std::time::Duration;
-
-	use super::*;
-
-	fn make_session() -> UdpSession {
-		UdpSession::new(
-			0x1234,
-			"127.0.0.1:9999".parse().unwrap(),
-			"127.0.0.1".parse().unwrap(),
-			None,
-			1500,
-		)
-		.expect("binding 127.0.0.1:0 must succeed in tests")
-	}
-
-	#[tokio::test]
-	async fn idle_grows_over_time() {
-		let session = make_session();
-		// A fresh session should be roughly zero-idle.
-		assert!(session.idle_for() < Duration::from_millis(50));
-
-		tokio::time::sleep(Duration::from_millis(80)).await;
-		let idle = session.idle_for();
-		assert!(idle >= Duration::from_millis(60), "idle should grow to ~80ms, got {idle:?}");
-	}
-
-	#[tokio::test]
-	async fn touch_resets_idle() {
-		let session = make_session();
-		tokio::time::sleep(Duration::from_millis(80)).await;
-		assert!(session.idle_for() >= Duration::from_millis(60));
-
-		session.touch();
-		let after_touch = session.idle_for();
-		assert!(
-			after_touch < Duration::from_millis(30),
-			"touch should reset idle to near-zero, got {after_touch:?}"
-		);
-	}
-
-	#[tokio::test]
-	async fn touch_is_shared_across_clones() {
-		// Sessions are cloned into recv loop, idle watcher, and the inbound packet
-		// handler — touches from one clone must be visible to all readers.
-		let a = make_session();
-		let b = a.clone();
-
-		tokio::time::sleep(Duration::from_millis(80)).await;
-		assert!(b.idle_for() >= Duration::from_millis(60));
-
-		a.touch();
-		assert!(
-			b.idle_for() < Duration::from_millis(30),
-			"touch on one clone must propagate to the other"
-		);
 	}
 }

--- a/tuic-server/src/connection/handle_task.rs
+++ b/tuic-server/src/connection/handle_task.rs
@@ -1,4 +1,5 @@
 use std::{
+	collections::hash_map::Entry,
 	io::{Error as IoError, ErrorKind},
 	net::{IpAddr, SocketAddr},
 };
@@ -328,13 +329,19 @@ impl Connection {
 				src_addr = addr
 			);
 
-			let session = match self.udp_sessions.get(&assoc_id).await {
-				Some(s) => s,
-				None => {
-					let session = UdpSession::new(self.ctx.clone(), self.clone(), assoc_id, self.udp_sessions.clone())?;
-					self.udp_sessions.insert(assoc_id, session.clone()).await;
-					session
-				}
+			let guard = self.udp_sessions.read().await;
+			let session = guard.get(&assoc_id).map(|v| v.to_owned());
+			drop(guard);
+			let session = match session {
+				Some(v) => v,
+				None => match self.udp_sessions.write().await.entry(assoc_id) {
+					Entry::Occupied(entry) => entry.get().clone(),
+					Entry::Vacant(entry) => {
+						let session = UdpSession::new(self.ctx.clone(), self.clone(), assoc_id)?;
+						entry.insert(session.clone());
+						session
+					}
+				},
 			};
 
 			// Resolve using default outbound and apply ACL
@@ -392,7 +399,11 @@ impl Connection {
 
 			let uuid = self.auth.get().ok_or_eyre("Unexpected authorization state")?;
 			restful::traffic_tx(&self.ctx, &uuid, pkt.len());
-			session.send(pkt, socket_addr).await
+			if let Some(session) = session.upgrade() {
+				session.send(pkt, socket_addr).await
+			} else {
+				Err(eyre!("UdpSession dropped already").into())
+			}
 		};
 
 		if let Err(err) = process.await {
@@ -406,7 +417,9 @@ impl Connection {
 	pub async fn handle_dissociate(&self, assoc_id: u16) {
 		info!("[UDP-DROP] [{assoc_id:#06x}]");
 
-		if let Some(session) = self.udp_sessions.remove(&assoc_id).await {
+		if let Some(session) = self.udp_sessions.write().await.remove(&assoc_id)
+			&& let Some(session) = session.upgrade()
+		{
 			session.close().await;
 		}
 	}

--- a/tuic-server/src/connection/mod.rs
+++ b/tuic-server/src/connection/mod.rs
@@ -1,11 +1,14 @@
-use std::{sync::Arc, time::Duration};
+use std::{
+	collections::HashMap,
+	sync::{Arc, Weak},
+	time::Duration,
+};
 
 use arc_swap::ArcSwap;
 use bytes::Bytes;
-use moka::future::Cache;
 use peekable::tokio::AsyncPeekExt;
 use smallvec::SmallVec;
-use tokio::time;
+use tokio::{sync::RwLock as AsyncRwLock, time};
 use tracing::{Instrument, Span, debug, info, info_span, warn};
 use tuic_core::quinn::{Authenticate, Connecting, Connection as Model, QuinnConnection, VarInt, side};
 
@@ -53,7 +56,7 @@ pub struct Connection {
 	inner: QuinnConnection,
 	model: Model<side::Server>,
 	auth: Authenticated,
-	udp_sessions: Cache<u16, Arc<UdpSession>>,
+	udp_sessions: Arc<AsyncRwLock<HashMap<u16, Weak<UdpSession>>>>,
 	udp_relay_mode: Arc<ArcSwap<Option<UdpRelayMode>>>,
 }
 
@@ -154,7 +157,7 @@ impl Connection {
 			inner: conn.clone(),
 			model: Model::<side::Server>::new(conn),
 			auth: Authenticated::new(),
-			udp_sessions: Cache::new(u16::MAX as u64),
+			udp_sessions: Arc::new(AsyncRwLock::new(HashMap::new())),
 			udp_relay_mode: Arc::new(ArcSwap::new(None.into())),
 		}
 	}

--- a/tuic-server/src/connection/udp_session.rs
+++ b/tuic-server/src/connection/udp_session.rs
@@ -1,17 +1,16 @@
 use std::{
 	io::Error as IoError,
 	net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket as StdUdpSocket},
-	sync::Arc,
+	sync::{Arc, Weak},
 };
 
 use bytes::Bytes;
-use moka::future::Cache;
 use socket2::{Domain, Protocol, SockAddr, Socket, Type};
 use tokio::{
 	net::UdpSocket,
 	sync::{RwLock as AsyncRwLock, oneshot},
 };
-use tracing::{Instrument, Span, debug, warn};
+use tracing::{Instrument, Span, warn};
 use tuic_core::Address;
 
 use super::Connection;
@@ -20,24 +19,15 @@ use crate::{AppContext, error::Error, utils::FutResultExt};
 pub struct UdpSession {
 	ctx: Arc<AppContext>,
 	assoc_id: u16,
-	udp_sessions: Cache<u16, Arc<UdpSession>>,
+	conn: Connection,
 	socket_v4: UdpSocket,
 	socket_v6: Option<UdpSocket>,
 	close: AsyncRwLock<Option<oneshot::Sender<()>>>,
 }
 
 impl UdpSession {
-	/// Spawn a listen task for the UDP session and return an `Arc<Self>`.
-	///
-	/// The listen task is the session's real owner; when it ends the session
-	/// is dropped. `conn` is consumed and moved into the listen task for
-	/// outgoing packet relay (`relay_packet`).
-	pub fn new(
-		ctx: Arc<AppContext>,
-		conn: Connection,
-		assoc_id: u16,
-		udp_sessions: Cache<u16, Arc<UdpSession>>,
-	) -> Result<Arc<Self>, Error> {
+	// spawn a task which actually owns itself, then return its wake reference.
+	pub fn new(ctx: Arc<AppContext>, conn: Connection, assoc_id: u16) -> Result<Weak<Self>, Error> {
 		let socket_v4 = {
 			let socket = Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP))
 				.map_err(|err| Error::Socket("failed to create UDP associate IPv4 socket", err))?;
@@ -76,96 +66,63 @@ impl UdpSession {
 
 		let (tx, rx) = oneshot::channel();
 
-		let ctx_listening = ctx.clone();
 		let session = Arc::new(Self {
-			ctx,
+			ctx: ctx.clone(),
+			conn,
 			assoc_id,
-			udp_sessions,
 			socket_v4,
 			socket_v6,
 			close: AsyncRwLock::new(Some(tx)),
 		});
 
 		let session_listening = session.clone();
-		let conn_listening = conn; // moved here, used by listen task for relay
+		// UdpSession's real owner.
 		let listen_span = Span::current();
 		let listen = async move {
 			let span = Span::current();
 			let mut rx = rx;
-			let mut timeout = tokio::time::interval(ctx_listening.cfg.stream_timeout);
+			let mut timeout = tokio::time::interval(ctx.cfg.stream_timeout);
 			timeout.reset();
-			let mut health_check = tokio::time::interval(ctx_listening.cfg.gc_interval);
-			health_check.reset();
-
-			enum Event {
-				Packet(Result<(Bytes, SocketAddr), IoError>),
-				Timeout,
-				CloseSignal,
-				HealthCheck,
-			}
 
 			loop {
-				let event = tokio::select! {
-					res = session_listening.recv()  => Event::Packet(res),
-					_  = timeout.tick()              => Event::Timeout,
-					_  = &mut rx                     => Event::CloseSignal,
-					_  = health_check.tick()          => Event::HealthCheck,
-				};
-
-				match event {
-					Event::Packet(res) => {
-						timeout.reset();
-
-						let (pkt, addr) = match res {
-							Ok(v) => v,
-							Err(err) => {
-								warn!(
-									"[packet] [{assoc_id:#06x}] outbound listening error: {err}",
-									assoc_id = session_listening.assoc_id
-								);
-								continue;
-							}
-						};
-
-						tokio::spawn(
-							conn_listening
-								.clone()
-								.relay_packet(pkt, Address::SocketAddress(addr), session_listening.assoc_id)
-								.log_err()
-								.instrument(span.clone()),
-						);
-					}
-					Event::Timeout => {
-						if conn_listening.is_closed() {
-							debug!(
-								"[packet] [{assoc_id:#06x}] parent connection closed, cleaning up",
-								assoc_id = session_listening.assoc_id
-							);
-							break;
-						}
+				let next;
+				tokio::select! {
+					recv = session_listening.recv() => next = recv,
+					// Avoid client didn't send `UDP-DROP` properly
+					_ = timeout.tick() => {
 						session_listening.close().await;
+						warn!("[packet] [{assoc_id:#06x}] UDP session timeout", assoc_id = session_listening.assoc_id);
+						continue;
+					},
+					// `UDP-DROP`
+					_ = &mut rx => break
+				}
+				timeout.reset();
+				let (pkt, addr) = match next {
+					Ok(v) => v,
+					Err(err) => {
 						warn!(
-							"[packet] [{assoc_id:#06x}] UDP session timeout",
+							"[packet] [{assoc_id:#06x}] outbound listening error: {err}",
 							assoc_id = session_listening.assoc_id
 						);
+						continue;
 					}
-					Event::CloseSignal => break,
-					Event::HealthCheck => {
-						if conn_listening.is_closed() {
-							debug!(
-								"[packet] [{assoc_id:#06x}] parent connection closed, cleaning up",
-								assoc_id = session_listening.assoc_id
-							);
-							break;
-						}
-					}
-				}
+				};
+
+				tokio::spawn(
+					session_listening
+						.conn
+						.clone()
+						.relay_packet(pkt, Address::SocketAddress(addr), session_listening.assoc_id)
+						.log_err()
+						.instrument(span.clone()),
+				);
 			}
-			session_listening.udp_sessions.invalidate(&assoc_id).await;
+			session_listening.conn.udp_sessions.write().await.remove(&assoc_id);
 		};
 
 		tokio::spawn(listen.instrument(listen_span));
-		Ok(session)
+		Ok(Arc::downgrade(&session))
 	}
 
 	pub async fn send(&self, pkt: Bytes, mut addr: SocketAddr) -> Result<(), Error> {


### PR DESCRIPTION
## What

Reverts the moka concurrent-cache UDP session implementation introduced in #114 (`perf: replace management-path locks with moka concurrent cache`) back to the original `Arc<AsyncRwLock<HashMap<..>>>` lock-based maps, on **both client and server**.

## Why

Going back to the original lock-based UDP session management. #114 swapped the UDP session maps over to `moka::future::Cache`; this restores the pre-moka implementation.

## How

The affected files are restored to their pre-moka (`6debab3~1`) state, with two exceptions handled surgically because those files also accumulated unrelated changes after #114:

| File | Method |
|------|--------|
| server `udp_session.rs`, `handle_task.rs` | literal pre-moka restore |
| client `forward.rs`, `lib.rs`, `socks5/{handle_task,mod,udp_session}.rs` | literal pre-moka restore |
| server `connection/mod.rs`, client `connection/{mod,handle_task}.rs` | **surgical** — only the moka `Cache` is flipped back to the lock-based type; unrelated #122 (quinn re-export) / #126 (removed stream counters) updates are preserved so the crates still build |

- Server `udp_sessions` → `Arc<AsyncRwLock<HashMap<u16, Weak<UdpSession>>>>` with `Weak`-based ownership.
- Client `socks5_udp_sessions` / `fwd_udp_sessions` → lock-based maps; the **moka dependency is dropped from `tuic-client`**.
- The server still uses moka in the restful/traffic-stats path (`lib.rs`/`restful.rs`), which predates #114 and is intentionally left in place.

## ⚠️ Intentionally dropped changes

Because the files are restored to their pre-moka state, later changes that lived in them are rolled back:

- **#134** — close orphaned UDP sessions when the parent QUIC connection drops. This bug returns; cleanup falls back to the original timeout path.
- **#129** — client UDP session lifecycle (idle expiry, wraparound id allocation, cleanup).
- **#131** — optional SOCKS5 server / forward-only mode.

`local.server` is `Option<SocketAddr>` in the current config (from #131), so the now-mandatory SOCKS5 listen address is unwrapped with a clear startup error (`local.server (SOCKS5 listen address) is required`) instead of a panic.

## Verification

- `cargo check --workspace --all-targets` ✅
- `cargo clippy` ✅ (no warnings)
- `cargo +nightly fmt --check` ✅
- Unit tests: **51 + 120 pass** ✅
- Integration tests (`tuic-tests`): **9/9 pass** ✅ (end-to-end relay, TCP/UDP forward, IPv6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
