### PR TITLE
fix(server): close orphaned UDP sessions on parent QUIC drop (re-port #134)

### DIFF
--- a/tuic-server/src/connection/udp_session.rs
+++ b/tuic-server/src/connection/udp_session.rs
@@ -10,7 +10,7 @@ use tokio::{
 	net::UdpSocket,
 	sync::{RwLock as AsyncRwLock, oneshot},
 };
-use tracing::{Instrument, Span, warn};
+use tracing::{Instrument, Span, debug, warn};
 use tuic_core::Address;
 
 use super::Connection;
@@ -88,6 +88,16 @@ impl UdpSession {
 				let next;
 				tokio::select! {
 					recv = session_listening.recv() => next = recv,
+					// Parent QUIC connection dropped without a proper `UDP-DROP`: tear down
+					// immediately instead of lingering until `stream_timeout` (or forever, if
+					// the target keeps sending and resetting the timeout).
+					_ = session_listening.conn.inner.closed() => {
+						debug!(
+							"[packet] [{assoc_id:#06x}] parent connection closed, cleaning up",
+							assoc_id = session_listening.assoc_id
+						);
+						break;
+					},
 					// Avoid client didn't send `UDP-DROP` properly
 					_ = timeout.tick() => {
 						session_listening.close().await;
@@ -118,7 +128,13 @@ impl UdpSession {
 						.instrument(span.clone()),
 				);
 			}
-			session_listening.conn.udp_sessions.write().await.remove(&assoc_id);
+			// Only drop our own map entry. If this assoc_id was re-used and replaced by a
+			// newer session while we were shutting down, leave that entry intact.
+			let self_weak = Arc::downgrade(&session_listening);
+			let mut sessions = session_listening.conn.udp_sessions.write().await;
+			if sessions.get(&assoc_id).is_some_and(|entry| entry.ptr_eq(&self_weak)) {
+				sessions.remove(&assoc_id);
+			}
 		};
 
 		tokio::spawn(listen.instrument(listen_span));


### PR DESCRIPTION
## What

Re-port the #134 fix — *close orphaned UDP sessions when the parent QUIC connection drops* — onto the lock-based session map, and add a guard against `assoc_id` reuse clobbering a live session.

## Why

`#114` moved the session maps to a moka cache; `#134` built its orphan-cleanup on top of that version (using `invalidate()` + a `gc_interval` health-check tick). When `#135` reverted the moka change, it restored a **pre-#134 snapshot** of `udp_session.rs` as collateral, silently dropping the cleanup.

At HEAD, a UDP associate whose parent QUIC connection dies without a `Dissociate` is only reaped by the `stream_timeout` backstop (default **60s**) — there is no `is_closed()` check anywhere in the listen loop. Worse, a *chatty* target that keeps sending resets the timeout on every inbound packet (`relay_packet` just fails with `connection lost` and continues), so the relay sockets can be held **indefinitely** after the client is gone.

Operationally this shows up as inflated open UDP FDs under reconnect churn — sessions on dead connections lingering ~a minute (or longer) before cleanup, e.g. a connection dropping at `T` whose associates only `UDP session timeout` at `T+60s`.

## What changed

`tuic-server/src/connection/udp_session.rs`:

1. **Prompt teardown on parent close** — the listen loop now `select!`s on `conn.inner.closed()` and breaks immediately when the parent QUIC connection ends. This uses quinn's `closed()` future (the same pattern already in `handle_stream.rs`), so teardown is instant rather than polled on a tick as in the original #134.
2. **assoc_id-reuse guard** — the task's self-removal from the map is now conditional via `Weak::ptr_eq`: it only deletes the entry if it still points to *this* session, so a re-used `assoc_id` that was replaced by a newer session is left intact.

## Behavior

- Dropped/idle QUIC connection → its UDP associates release their relay sockets at once, instead of lingering up to `stream_timeout` (or forever for a chatty peer).
- Normal `UDP-DROP` and `stream_timeout` paths are unchanged; the conditional removal is a no-op in those cases (entry already gone, or still ours).

## Testing

- `cargo check -p tuic-server` — clean
- `cargo test -p tuic-server` — 120 passed
- `cargo test -p tuic-tests` — 9 passed, including `test_fragmented_udp_packets` and `test_tcp_udp_forward_integration` (real server+client UDP relay over loopback)

## Reviewer notes

- `conn.inner` / `conn.udp_sessions` are private fields of `Connection`, but `udp_session` is a child module so the access is in-crate (the final-removal already reached into `udp_sessions`).
- Follow-up worth considering: a regression test asserting the sessions map empties promptly after the client connection closes (happy to add here if preferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
