### PR TITLE
feat: add optional dhat heap profiling for leak detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +404,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -742,6 +772,22 @@ dependencies = [
  "rustc_version",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "thousands",
 ]
 
 [[package]]
@@ -1138,6 +1184,12 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "h2"
@@ -1725,6 +1777,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mintex"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1825,6 +1892,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2093,7 +2169,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto 0.11.14",
  "quinn-udp 0.5.14",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "socket2 0.6.4",
  "thiserror 2.0.18",
@@ -2113,7 +2189,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto 0.12.0",
  "quinn-udp 0.6.1",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "socket2 0.6.4",
  "thiserror 2.0.18",
@@ -2144,7 +2220,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -2167,7 +2243,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_pcg",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -2405,6 +2481,18 @@ dependencies = [
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -2994,6 +3082,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
+
+[[package]]
 name = "thread_local"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3406,6 +3500,7 @@ dependencies = [
  "chrono",
  "clap",
  "crossbeam-utils",
+ "dhat",
  "educe",
  "eyre",
  "figment",
@@ -3473,6 +3568,7 @@ dependencies = [
  "chrono",
  "clap",
  "derive_more",
+ "dhat",
  "educe",
  "eyre",
  "figment",

--- a/README.md
+++ b/README.md
@@ -78,6 +78,19 @@ There are 4 crates provided in this repository:
 
 Contributors should fork from the `main` branch and submit pull requests to the `main` branch. Please note that the `dev` branch may be force-pushed from time to time, so avoid basing your work on it.
 
+### Heap profiling / leak detection
+
+Both `tuic-server` and `tuic-client` ship an optional [dhat](https://crates.io/crates/dhat) heap profiler behind the `dhat-heap` feature, useful for chasing resource/memory leaks (e.g. UDP sessions that are never cleaned up).
+
+```bash
+# Build & run the server with profiling enabled
+cargo run -p tuic-server --features dhat-heap -- -c config.toml
+```
+
+Exercise the binary, then stop it with **Ctrl-C** (a graceful shutdown is required — a hard kill skips the profiler). On exit a `dhat-heap.json` file is written to the working directory; open it in the [DHAT viewer](https://nnethercote.github.io/dh_view/dh_view.html) and inspect the **"At t-end"** (at-exit) numbers — blocks still alive when the process shut down are your leaks, and each is annotated with the allocation backtrace.
+
+Note: `dhat-heap` installs its own global allocator, so it is mutually exclusive with `jemallocator` (dhat takes precedence if both are enabled). Leave it off for release/production builds — it adds per-allocation overhead.
+
 ## Contributors
 
 Thanks to all the contributors who have helped improve TUIC!

--- a/tuic-client/Cargo.toml
+++ b/tuic-client/Cargo.toml
@@ -16,6 +16,11 @@ default = ["aws-lc-rs"]
 ring = ["tuic-core/ring", "rustls/ring"]
 aws-lc-rs = ["tuic-core/aws-lc-rs", "dep:aws-lc-rs", "rustls/aws-lc-rs"]
 jemallocator = ["tikv-jemallocator"]
+# Heap profiling / resource-leak detection via dhat. Replaces the global
+# allocator (mutually exclusive with `jemallocator`, dhat wins) and pulls in
+# tokio's signal support so Ctrl-C can shut the client down cleanly, letting the
+# profiler flush its report on exit.
+dhat-heap = ["dep:dhat", "tokio/signal"]
 
 [dependencies]
 num_cpus = "1"
@@ -65,6 +70,7 @@ chrono = "0.4"
 tracing = "0.1"
 
 tikv-jemallocator = { version = "0.7", optional = true }
+dhat = { version = "0.3", optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/tuic-client/src/main.rs
+++ b/tuic-client/src/main.rs
@@ -2,16 +2,29 @@ use std::{process, str::FromStr};
 
 use chrono::{Offset, TimeZone};
 use clap::Parser;
-#[cfg(feature = "jemallocator")]
+#[cfg(all(feature = "jemallocator", not(feature = "dhat-heap")))]
 use tikv_jemallocator::Jemalloc;
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use tuic_client::config::{Cli, Config, EnvState, ResolvedRuntime};
-#[cfg(feature = "jemallocator")]
+// dhat takes over the global allocator to trace every heap allocation, so it
+// must be the sole `#[global_allocator]`; jemalloc is disabled whenever
+// `dhat-heap` is enabled.
+#[cfg(all(feature = "jemallocator", not(feature = "dhat-heap")))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 
+#[cfg(feature = "dhat-heap")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
 fn main() -> eyre::Result<()> {
+	// Profile the whole process. Dropping the guard on graceful shutdown writes
+	// `dhat-heap.json`; its at-exit ("t-end") stats show allocations still live
+	// at exit, i.e. leaked resources.
+	#[cfg(feature = "dhat-heap")]
+	let _dhat = dhat::Profiler::new_heap();
+
 	#[cfg(feature = "aws-lc-rs")]
 	{
 		_ = rustls::crypto::aws_lc_rs::default_provider().install_default();
@@ -58,5 +71,27 @@ fn main() -> eyre::Result<()> {
 
 	let rt = builder.enable_all().build()?;
 
-	rt.block_on(async move { tuic_client::run(cfg).await })
+	// `run` never returns on its own (the SOCKS5 accept loop runs forever), so a
+	// plain Ctrl-C would hard-kill the process and skip the profiler's `Drop`.
+	// Under `dhat-heap`, race it against Ctrl-C so shutdown is graceful and
+	// `dhat-heap.json` gets written.
+	#[cfg(feature = "dhat-heap")]
+	let result = rt.block_on(async move {
+		tokio::select! {
+			res = tuic_client::run(cfg) => res,
+			_ = tokio::signal::ctrl_c() => {
+				tracing::info!("Received Ctrl-C, shutting down.");
+				Ok(())
+			}
+		}
+	});
+
+	#[cfg(not(feature = "dhat-heap"))]
+	let result = rt.block_on(async move { tuic_client::run(cfg).await });
+
+	// Drop the runtime (aborting spawned tasks and freeing their resources)
+	// before `_dhat` falls out of scope, so the leak report reflects a clean
+	// shutdown rather than in-flight work.
+	drop(rt);
+	result
 }

--- a/tuic-server/Cargo.toml
+++ b/tuic-server/Cargo.toml
@@ -16,6 +16,9 @@ default = ["aws-lc-rs"]
 ring = ["tuic-core/ring", "rustls/ring", "rcgen/ring", "rustls-acme/ring"]
 aws-lc-rs = ["tuic-core/aws-lc-rs", "dep:aws-lc-rs", "rustls/aws-lc-rs", "rcgen/aws_lc_rs", "rustls-acme/aws-lc-rs"]
 jemallocator = ["tikv-jemallocator"]
+# Heap profiling / resource-leak detection via dhat. Replaces the global
+# allocator, so it is mutually exclusive with `jemallocator` (dhat wins).
+dhat-heap = ["dep:dhat"]
 
 [dependencies]
 h3 = "0.0.8"
@@ -83,6 +86,7 @@ peekable = { version = "0.6.1", default-features = false, features = ["tokio"] }
 smallvec = { version = "1", default-features = false }
 
 tikv-jemallocator = { version = "0.7", optional = true }
+dhat = { version = "0.3", optional = true }
 rand = "0.10"
 
 [dev-dependencies]

--- a/tuic-server/src/main.rs
+++ b/tuic-server/src/main.rs
@@ -1,18 +1,31 @@
 use std::process;
 
 use clap::Parser;
-#[cfg(feature = "jemallocator")]
+#[cfg(all(feature = "jemallocator", not(feature = "dhat-heap")))]
 use tikv_jemallocator::Jemalloc;
 use tuic_server::{
 	config::{Cli, Control, EnvState, ResolvedRuntime, parse_config},
 	log,
 };
 
-#[cfg(feature = "jemallocator")]
+// dhat takes over the global allocator to trace every heap allocation, so it
+// must be the sole `#[global_allocator]`; jemalloc is disabled whenever
+// `dhat-heap` is enabled.
+#[cfg(all(feature = "jemallocator", not(feature = "dhat-heap")))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 
+#[cfg(feature = "dhat-heap")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
 fn main() -> eyre::Result<()> {
+	// Profile the whole process. Dropping the guard on graceful shutdown writes
+	// `dhat-heap.json`; its at-exit ("t-end") stats show allocations still live
+	// at exit, i.e. leaked resources.
+	#[cfg(feature = "dhat-heap")]
+	let _dhat = dhat::Profiler::new_heap();
+
 	#[cfg(feature = "aws-lc-rs")]
 	{
 		_ = rustls::crypto::aws_lc_rs::default_provider().install_default();


### PR DESCRIPTION
## What

Adds an optional [dhat](https://crates.io/crates/dhat) heap profiler behind a new `dhat-heap` feature in both `tuic-server` and `tuic-client`, to help track down resource/memory leaks (e.g. UDP sessions that are never cleaned up — the area of several recent fixes: #126, #129, #134, #136).

## Why

The codebase has had a string of UDP-session lifecycle/leak fixes recently. A built-in heap profiler makes it easy to reproduce and locate such leaks: build with the feature, exercise the binary, shut it down gracefully, and inspect what is still allocated at exit — each block annotated with its allocation backtrace.

## How

- New optional `dhat` dependency + `dhat-heap` feature on both binaries.
- Under `dhat-heap`, `dhat::Alloc` becomes the `#[global_allocator]`. Only one global allocator may exist, so it is **mutually exclusive with `jemallocator`** (dhat takes precedence); the jemalloc import/static `cfg` is aligned to `not(feature = "dhat-heap")` to avoid an unused-import warning when both are enabled.
- A `dhat::Profiler` guard is held for the whole process in `main`; dropping it on a graceful shutdown writes `dhat-heap.json`, whose **"At t-end"** stats show allocations still alive at exit (i.e. leaks).
- **Client graceful shutdown:** the client's `run()` never returns on its own (the SOCKS5 accept loop runs forever), so a hard kill would skip the profiler's `Drop` and produce no report. Under `dhat-heap` the run future is raced against `ctrl_c()`, and the Tokio runtime is dropped before the profiler so the report reflects a clean stop rather than in-flight work. This pulls in `tokio/signal` for that feature only. The server already shuts down cleanly on Ctrl-C, so it needed no flow change.
- README: added a "Heap profiling / leak detection" section under Contributing.

## Usage

```bash
cargo run -p tuic-server --features dhat-heap -- -c config.toml
# generate some load, then Ctrl-C to shut down gracefully
# -> dhat-heap.json in the working dir; open in https://nnethercote.github.io/dh_view/dh_view.html
#    and read the "At t-end" column to find leaked allocations
```

## Notes for reviewers

- `dhat-heap` is dev/profiling-only — it is **not** added to any release/CI build target (it adds per-allocation overhead).
- Verified locally: default build (server + client), `dhat-heap` build (server + client), and `cargo clippy --features dhat-heap -- -D warnings` on both crates (passes the workspace's strict lints).
- The combined `jemallocator,dhat-heap` build could not be compiled on the dev machine (local `tikv-jemalloc-sys` has no C toolchain), but the `cfg` gating is logically aligned — the jemalloc import and static share identical `cfg`s, so they are always present/absent together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
