### PR TITLE
fix(server): don't bind UDP session before ACL/resolve (socket leak)

### DIFF
--- a/tuic-server/src/connection/handle_task.rs
+++ b/tuic-server/src/connection/handle_task.rs
@@ -329,22 +329,9 @@ impl Connection {
 				src_addr = addr
 			);
 
-			let guard = self.udp_sessions.read().await;
-			let session = guard.get(&assoc_id).map(|v| v.to_owned());
-			drop(guard);
-			let session = match session {
-				Some(v) => v,
-				None => match self.udp_sessions.write().await.entry(assoc_id) {
-					Entry::Occupied(entry) => entry.get().clone(),
-					Entry::Vacant(entry) => {
-						let session = UdpSession::new(self.ctx.clone(), self.clone(), assoc_id)?;
-						entry.insert(session.clone());
-						session
-					}
-				},
-			};
-
-			// Resolve using default outbound and apply ACL
+			// Resolve the target and run ACL/outbound policy BEFORE creating a session, so
+			// packets that are dropped, blocked, or fail to resolve don't leak an outbound
+			// socket pair (+ listen task) for the whole `stream_timeout` window.
 			let initial_addrs: Vec<SocketAddr> = resolve_dns(&addr).await?.collect();
 			if initial_addrs.is_empty() {
 				return Err(Error::from(IoError::new(ErrorKind::NotFound, "no address resolved")));
@@ -395,6 +382,23 @@ impl Connection {
 			} else {
 				// Use the first address resolved
 				initial_addrs[0]
+			};
+
+			// Get-or-create the UDP session (binding its outbound sockets) only now that the
+			// packet has passed ACL/outbound policy — never for dropped/blocked packets.
+			let guard = self.udp_sessions.read().await;
+			let session = guard.get(&assoc_id).map(|v| v.to_owned());
+			drop(guard);
+			let session = match session {
+				Some(v) => v,
+				None => match self.udp_sessions.write().await.entry(assoc_id) {
+					Entry::Occupied(entry) => entry.get().clone(),
+					Entry::Vacant(entry) => {
+						let session = UdpSession::new(self.ctx.clone(), self.clone(), assoc_id)?;
+						entry.insert(session.clone());
+						session
+					}
+				},
 			};
 
 			let uuid = self.auth.get().ok_or_eyre("Unexpected authorization state")?;

--- a/tuic-server/src/connection/handle_task.rs
+++ b/tuic-server/src/connection/handle_task.rs
@@ -384,8 +384,9 @@ impl Connection {
 				initial_addrs[0]
 			};
 
-			// Get-or-create the UDP session (binding its outbound sockets) only now that the
-			// packet has passed ACL/outbound policy — never for dropped/blocked packets.
+			// Get-or-create the UDP session (binding its outbound sockets) only now that
+			// the packet has passed ACL/outbound policy — never for dropped/blocked
+			// packets.
 			let guard = self.udp_sessions.read().await;
 			let session = guard.get(&assoc_id).map(|v| v.to_owned());
 			drop(guard);


### PR DESCRIPTION
## What

Create the UDP relay session — and bind its outbound socket pair + spawn the listen task — only **after** the packet has passed ACL / DNS / outbound-policy, instead of up front.

## Why

In `handle_packet`, the session was created first, then the target was resolved and ACL-checked. So a UDP packet that is then **dropped** (ACL `drop`), **blocked** (socks5 outbound without `allow_udp`), or **fails to resolve** still left a bound outbound UDP socket pair + listen task alive for the whole `stream_timeout` window (default 60s). Under `assoc_id` churn toward blocked/unresolvable destinations this inflates the open UDP FD count for no reason.

This pairs with the orphaned-session cleanup from #136: that bounds sessions by connection lifetime; this stops creating them at all for packets we're going to discard.

> Note: this fix previously existed on the tree (`c2c0033` + the `f1adff8` rustfmt rewrap) but was dropped from `main` during a branch cleanup. This PR restores it cleanly on top of current `main` (`ef35d72`), preserving the two original commits rather than the tangled history they were stranded on.

## Change

`tuic-server/src/connection/handle_task.rs` — move the get-or-create `UdpSession` block down, to just before the relay `send()`, after the ACL/outbound decision and `socket_addr` computation. Dropped/blocked/unresolved packets now return without ever allocating a session.

## Testing

- `cargo test -p tuic-server` — pass
- `cargo test -p tuic-tests` — 9 passed, including `test_tcp_udp_forward_integration` (real server+client UDP relay over loopback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
